### PR TITLE
refactor(engine): data-driven movement + fix knight direction (stage 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,11 @@ before scoping — do NOT start building features until the scope is agreed.
 - Board is a fixed **3×4 minichess**; pawn promotes to knight at `j==3` (`gameState.dart`).
 - AI in `ai_controller.dart` (minimax-ish eval). Note: `getPlay` returns early at the
   `return makeLocalDecision()` — the remote-play block below it is **dead/unreachable**.
-- Known bug: knight movement compares `possession` to `player` (always false) → `else`
-  branch always runs. NOT fixed yet (production); flagged for user decision.
+- Movement is now **data-driven** via `engine/rules.dart` `pieceOffsets()` (Stage 3).
+  This also fixed the old knight bug (it compared `possession` to `player`, so the enemy
+  knight's diagonals were mirrored wrong — only affected the AI's king-safety heuristic,
+  since this game has no check). The knight (an invented promoted-pawn piece) now mirrors
+  by owner like the pawn.
 
 ## Build / run
 - Emulator alias in user's zsh: **`celular`** → launches AVD `@Small_Phone`. Mobile-first,

--- a/lib/app/engine/rules.dart
+++ b/lib/app/engine/rules.dart
@@ -7,9 +7,8 @@ import '../utils/gameObjects/tile.dart';
 ///
 /// This library is intentionally free of Flutter / GetX / audio / IO imports so
 /// it can be unit-tested in isolation and reused by future game modes
-/// (rule modifiers, campaign/boss AI). Behaviour here is a verbatim extraction
-/// of the original logic that lived in `utils.dart` — see the characterization
-/// tests in `test/engine/` before changing any of it.
+/// (rule modifiers, campaign/boss AI). Movement is data-driven via
+/// [pieceOffsets]. See the characterization tests in `test/engine/`.
 
 bool isFromGraveyard(Tile tile) {
   return tile.i == null;
@@ -82,92 +81,76 @@ bool checkIfValidMove(Move m, GameState gs, [bool hard = false]) {
   }
 }
 
-bool isValidMovmentPerPiece(Move m, GameState gs, [bool hard = false]) {
-  switch (m.initialTile.char) {
+/// Relative `[di, dj]` steps a piece may take, from the perspective of its
+/// owner: `mine` advances toward +j, `enemy` toward -j, so direction-dependent
+/// pieces (pawn, knight) mirror automatically. The king's steps are gated
+/// separately by [hardSearchMove]; queen and empty have no moves.
+///
+/// This table is the single source of truth for movement — swap/extend it to
+/// add rule modifiers or new pieces.
+List<List<int>> pieceOffsets(chrt piece, possession owner) {
+  final fwd = owner == possession.mine ? 1 : -1;
+  switch (piece) {
     case chrt.pawn:
-      if (m.initialTile.owner == possession.mine) {
-        return m.initialTile.i! == m.finalTile.i &&
-            m.initialTile.j == (m.finalTile.j! - 1);
-      } else {
-        return m.initialTile.i! == m.finalTile.i &&
-            m.initialTile.j == (m.finalTile.j! + 1);
-      }
-    case chrt.king:
-      return (m.initialTile.i! + 1 == m.finalTile.i &&
-              m.initialTile.j! + 1 == m.finalTile.j &&
-              hardSearchMove(m, gs, hard)) ||
-          (m.initialTile.i! + 1 == m.finalTile.i &&
-              m.initialTile.j == m.finalTile.j &&
-              hardSearchMove(m, gs, hard)) ||
-          (m.initialTile.i! + 1 == m.finalTile.i &&
-              m.initialTile.j! - 1 == m.finalTile.j &&
-              hardSearchMove(m, gs, hard)) ||
-          (m.initialTile.i == m.finalTile.i &&
-              m.initialTile.j! + 1 == m.finalTile.j &&
-              hardSearchMove(m, gs, hard)) ||
-          (m.initialTile.i == m.finalTile.i &&
-              m.initialTile.j! - 1 == m.finalTile.j &&
-              hardSearchMove(m, gs, hard)) ||
-          (m.initialTile.i! - 1 == m.finalTile.i &&
-              m.initialTile.j! + 1 == m.finalTile.j &&
-              hardSearchMove(m, gs, hard)) ||
-          (m.initialTile.i! - 1 == m.finalTile.i &&
-              m.initialTile.j == m.finalTile.j &&
-              hardSearchMove(m, gs, hard)) ||
-          (m.initialTile.i! - 1 == m.finalTile.i &&
-              m.initialTile.j! - 1 == m.finalTile.j &&
-              hardSearchMove(m, gs, hard));
-    case chrt.bishop:
-      return (m.initialTile.i! + 1 == m.finalTile.i &&
-              m.initialTile.j! + 1 == m.finalTile.j) ||
-          (m.initialTile.i! + 1 == m.finalTile.i &&
-              m.initialTile.j! - 1 == m.finalTile.j) ||
-          (m.initialTile.i! - 1 == m.finalTile.i &&
-              m.initialTile.j! + 1 == m.finalTile.j) ||
-          (m.initialTile.i! - 1 == m.finalTile.i &&
-              m.initialTile.j! - 1 == m.finalTile.j);
-    case chrt.rock:
-      return (m.initialTile.i! + 1 == m.finalTile.i &&
-              m.initialTile.j == m.finalTile.j) ||
-          (m.initialTile.i == m.finalTile.i &&
-              m.initialTile.j! + 1 == m.finalTile.j) ||
-          (m.initialTile.i == m.finalTile.i &&
-              m.initialTile.j! - 1 == m.finalTile.j) ||
-          (m.initialTile.i! - 1 == m.finalTile.i &&
-              m.initialTile.j == m.finalTile.j);
+      return [
+        [0, fwd]
+      ];
     case chrt.knight:
-      if (m.initialTile.owner == player.white) {
-        return (m.initialTile.j! + 1 == m.finalTile.j &&
-                m.initialTile.i == m.finalTile.i) ||
-            (m.initialTile.j == m.finalTile.j &&
-                m.initialTile.i! + 1 == m.finalTile.i) ||
-            (m.initialTile.j == m.finalTile.j &&
-                m.initialTile.i! - 1 == m.finalTile.i) ||
-            (m.initialTile.j! - 1 == m.finalTile.j &&
-                m.initialTile.i == m.finalTile.i) ||
-            (m.initialTile.j! - 1 == m.finalTile.j &&
-                m.initialTile.i! + 1 == m.finalTile.i) ||
-            (m.initialTile.j! - 1 == m.finalTile.j &&
-                m.initialTile.i! - 1 == m.finalTile.i);
-      } else {
-        return (m.initialTile.j! + 1 == m.finalTile.j &&
-                m.initialTile.i == m.finalTile.i) ||
-            (m.initialTile.j == m.finalTile.j &&
-                m.initialTile.i! + 1 == m.finalTile.i) ||
-            (m.initialTile.j == m.finalTile.j &&
-                m.initialTile.i! - 1 == m.finalTile.i) ||
-            (m.initialTile.j! - 1 == m.finalTile.j &&
-                m.initialTile.i == m.finalTile.i) ||
-            (m.initialTile.j! + 1 == m.finalTile.j &&
-                m.initialTile.i! + 1 == m.finalTile.i) ||
-            (m.initialTile.j! + 1 == m.finalTile.j &&
-                m.initialTile.i! - 1 == m.finalTile.i);
-      }
+      // Invented piece (a promoted pawn): pushes forward — straight plus both
+      // forward diagonals — plus the two sides and a single step back.
+      return [
+        [0, fwd],
+        [1, 0],
+        [-1, 0],
+        [0, -fwd],
+        [1, fwd],
+        [-1, fwd],
+      ];
+    case chrt.bishop:
+      return const [
+        [1, 1],
+        [1, -1],
+        [-1, 1],
+        [-1, -1],
+      ];
+    case chrt.rock:
+      return const [
+        [1, 0],
+        [-1, 0],
+        [0, 1],
+        [0, -1],
+      ];
+    case chrt.king:
+      return const [
+        [1, 0],
+        [-1, 0],
+        [0, 1],
+        [0, -1],
+        [1, 1],
+        [1, -1],
+        [-1, 1],
+        [-1, -1],
+      ];
     case chrt.empty:
-      return false;
     case chrt.queen:
-      return false;
+      return const [];
   }
+}
+
+bool isValidMovmentPerPiece(Move m, GameState gs, [bool hard = false]) {
+  final di = m.finalTile.i! - m.initialTile.i!;
+  final dj = m.finalTile.j! - m.initialTile.j!;
+  final reachable = pieceOffsets(m.initialTile.char, m.initialTile.owner)
+      .any((o) => o[0] == di && o[1] == dj);
+  if (!reachable) return false;
+  // The king is the only piece whose move can be rejected — and only when
+  // `hard` is false (the AI's look-ahead, so it won't step its king onto a
+  // losing square). Every other piece may move into danger freely: this game
+  // has no check, you win by capturing the king.
+  if (m.initialTile.char == chrt.king) {
+    return hardSearchMove(m, gs, hard);
+  }
+  return true;
 }
 
 bool checkIfWin(Move move) {

--- a/test/engine/rules_test.dart
+++ b/test/engine/rules_test.dart
@@ -127,11 +127,12 @@ void main() {
     });
   });
 
-  // KNOWN bug locked on purpose: the knight branch compares `owner` (a
-  // `possession`) against `player.white` (always false), so mine and enemy
-  // knights share the exact same 6-move set. Revisit when we decide to fix it.
-  group('knight movement (current/buggy behaviour)', () {
-    final targets = <List<int>>[
+  // The knight is an invented piece (a promoted pawn). Like the pawn, its
+  // direction depends on the owner: mine pushes toward +j, enemy toward -j.
+  // (Stage 3 fixed the old owner-comparison bug where both shared one set.)
+  group('knight movement (direction depends on owner)', () {
+    // From (i=1, j=1): forward straight + sides + back straight + 2 forward diagonals.
+    final mineTargets = <List<int>>[
       [1, 2],
       [2, 1],
       [0, 1],
@@ -139,19 +140,37 @@ void main() {
       [2, 2],
       [0, 2],
     ];
-    test('mine and enemy knights share the same 6 destinations', () {
-      for (final o in [possession.mine, possession.enemy]) {
-        for (final t in targets) {
-          expect(
-              isValidMovmentPerPiece(
-                  _move(chrt.knight, o, 1, 1, t[0], t[1]), gs, true),
-              isTrue,
-              reason: 'owner=$o target=$t should be valid');
-        }
+    // Vertical mirror for the enemy (forward is -j).
+    final enemyTargets = <List<int>>[
+      [1, 0],
+      [2, 1],
+      [0, 1],
+      [1, 2],
+      [2, 0],
+      [0, 0],
+    ];
+    test('mine knight uses +j (forward) diagonals', () {
+      for (final t in mineTargets) {
+        expect(
+            isValidMovmentPerPiece(
+                _move(chrt.knight, possession.mine, 1, 1, t[0], t[1]), gs, true),
+            isTrue,
+            reason: 'mine target=$t');
       }
-    });
-    test('a cell outside that set is invalid', () {
+      // an enemy-only destination is not reachable for mine
       expect(isValidMovmentPerPiece(_move(chrt.knight, possession.mine, 1, 1, 0, 0),
+          gs, true), isFalse);
+    });
+    test('enemy knight mirrors to -j (forward) diagonals', () {
+      for (final t in enemyTargets) {
+        expect(
+            isValidMovmentPerPiece(
+                _move(chrt.knight, possession.enemy, 1, 1, t[0], t[1]), gs, true),
+            isTrue,
+            reason: 'enemy target=$t');
+      }
+      // a mine-only forward diagonal is not reachable for enemy
+      expect(isValidMovmentPerPiece(_move(chrt.knight, possession.enemy, 1, 1, 2, 2),
           gs, true), isFalse);
     });
   });


### PR DESCRIPTION
## What (Stage 3 of the engine refactor)
Replace the per-piece `switch` in `isValidMovmentPerPiece` with a single
**`pieceOffsets(piece, owner)`** table of relative `[di, dj]` steps. Movement is
now the engine's single source of truth — the groundwork for rule-modifiers and
new pieces.

## Knight fix (intended behaviour change)
The old code compared `owner` (a `possession`) against `player.white` — always
false — so the **enemy** knight's diagonals were never mirrored. Because this
game has **no check** (you win by capturing the king), the only effect was a
weaker AI king-safety heuristic: it could miss an enemy promoted-knight's
diagonal threat and walk its king into a capture. The knight (an invented
promoted-pawn piece) now mirrors by owner, exactly like the pawn.

- Behaviour-preserving for pawn / bishop / rock / king.
- Knight **enemy** direction corrected.

## Verification
- Characterization tests updated → **24/24 pass**
- `flutter analyze` clean (no new warnings)
- Android APK builds; web build runs in CI on this PR

Base: `dev`.
