### PR TITLE
feat(engine): data-driven BoardConfig for dimensions + promotion (stage 4)

### DIFF
--- a/lib/app/engine/board_config.dart
+++ b/lib/app/engine/board_config.dart
@@ -1,0 +1,29 @@
+import '../data/enums.dart';
+
+/// Shape and promotion rules of a board.
+///
+/// Pure data (no Flutter/GetX), so variants — e.g. a boss stage that grows the
+/// board — are just different [BoardConfig]s. The board rotates each turn, so
+/// everything here is expressed from the mover's ("mine") perspective.
+class BoardConfig {
+  /// Number of columns (the `i` axis).
+  final int width;
+
+  /// Number of rows (the `j` axis).
+  final int height;
+
+  /// What a pawn becomes when it reaches the far rank.
+  final chrt promotesTo;
+
+  const BoardConfig({
+    required this.width,
+    required this.height,
+    this.promotesTo = chrt.knight,
+  });
+
+  /// The current game: a 3×4 board, pawn promotes to a knight.
+  static const BoardConfig classic = BoardConfig(width: 3, height: 4);
+
+  /// Row a `mine` pawn promotes on (the far rank).
+  int get promotionRow => height - 1;
+}

--- a/lib/app/utils/gameObjects/gameState.dart
+++ b/lib/app/utils/gameObjects/gameState.dart
@@ -3,19 +3,26 @@ import 'package:inti_the_inka_chess_game/app/utils/gameObjects/tile.dart';
 
 import '../../data/enums.dart';
 
+import '../../engine/board_config.dart';
 import '../../engine/board_factory.dart';
 import '../../engine/rules.dart';
 import 'move.dart';
 
 class GameState {
-  GameState(this.board, this.myGraveyard, this.enemyGraveyard);
+  GameState(this.board, this.myGraveyard, this.enemyGraveyard,
+      {this.config = BoardConfig.classic});
 
-  GameState.named({board, myGraveyard, enemyGraveyard})
-      : this(board, myGraveyard, enemyGraveyard);
+  GameState.named(
+      {board,
+      myGraveyard,
+      enemyGraveyard,
+      BoardConfig config = BoardConfig.classic})
+      : this(board, myGraveyard, enemyGraveyard, config: config);
 
   List<List<Tile>> board;
   List<Tile> myGraveyard;
   List<Tile> enemyGraveyard;
+  final BoardConfig config;
 
   GameState changeGameState(Move move) {
     sendPieceToGrave(move);
@@ -24,8 +31,9 @@ class GameState {
   }
 
   transformPawn(Move move) {
-    if (move.finalTile.char == chrt.pawn && move.finalTile.j == 3) {
-      board[move.finalTile.j!][move.finalTile.i!].char = chrt.knight;
+    if (move.finalTile.char == chrt.pawn &&
+        move.finalTile.j == config.promotionRow) {
+      board[move.finalTile.j!][move.finalTile.i!].char = config.promotesTo;
     }
   }
 
@@ -75,6 +83,7 @@ class GameState {
       board: cloneBoard(gs.board),
       myGraveyard: [...gs.myGraveyard],
       enemyGraveyard: [...gs.enemyGraveyard],
+      config: gs.config,
     );
   }
 

--- a/test/engine/board_config_test.dart
+++ b/test/engine/board_config_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:inti_the_inka_chess_game/app/data/enums.dart';
+import 'package:inti_the_inka_chess_game/app/engine/board_config.dart';
+import 'package:inti_the_inka_chess_game/app/utils/gameObjects/gameState.dart';
+import 'package:inti_the_inka_chess_game/app/utils/gameObjects/move.dart';
+import 'package:inti_the_inka_chess_game/app/utils/gameObjects/tile.dart';
+
+List<List<Tile>> _board(int width, int height) => List.generate(height,
+    (j) => List.generate(width, (i) => Tile(chrt.empty, possession.none, i, j)));
+
+void main() {
+  group('BoardConfig', () {
+    test('classic is a 3x4 board that promotes pawns to knights', () {
+      expect(BoardConfig.classic.width, 3);
+      expect(BoardConfig.classic.height, 4);
+      expect(BoardConfig.classic.promotesTo, chrt.knight);
+      expect(BoardConfig.classic.promotionRow, 3);
+    });
+    test('promotionRow is the far rank (height - 1)', () {
+      expect(const BoardConfig(width: 5, height: 6).promotionRow, 5);
+    });
+  });
+
+  // Promotion happens in GameState.transformPawn, which now reads the config
+  // instead of the hardcoded `j == 3` / knight.
+  group('pawn promotion follows the board config', () {
+    test('classic: a pawn reaching the last row becomes a knight', () {
+      final board = _board(3, 4);
+      board[2][1] = Tile(chrt.pawn, possession.mine, 1, 2);
+      final gs = GameState.named(
+          board: board, myGraveyard: <Tile>[], enemyGraveyard: <Tile>[]);
+      gs.changeGameState(Move(board[2][1], board[3][1]));
+      expect(board[3][1].char, chrt.knight);
+    });
+    test('classic: a pawn short of the last row stays a pawn', () {
+      final board = _board(3, 4);
+      board[1][1] = Tile(chrt.pawn, possession.mine, 1, 1);
+      final gs = GameState.named(
+          board: board, myGraveyard: <Tile>[], enemyGraveyard: <Tile>[]);
+      gs.changeGameState(Move(board[1][1], board[2][1]));
+      expect(board[2][1].char, chrt.pawn);
+    });
+    test('a shorter config promotes on its own far rank', () {
+      final board = _board(3, 3); // height 3 -> promotionRow 2
+      board[1][1] = Tile(chrt.pawn, possession.mine, 1, 1);
+      final gs = GameState.named(
+        board: board,
+        myGraveyard: <Tile>[],
+        enemyGraveyard: <Tile>[],
+        config: const BoardConfig(width: 3, height: 3),
+      );
+      gs.changeGameState(Move(board[1][1], board[2][1]));
+      expect(board[2][1].char, chrt.knight);
+    });
+  });
+}


### PR DESCRIPTION
## What (Stage 4 of the engine refactor)
Introduce **`engine/board_config.dart`** — a pure `BoardConfig` holding the
board's `width`, `height`, `promotesTo`, and derived `promotionRow`, with a
`BoardConfig.classic` (3x4, pawn -> knight) preset.

- `GameState` now carries a `config` (defaults to `classic`).
- `transformPawn` reads `promotionRow` / `promotesTo` instead of the hardcoded
  `j == 3` / knight.

This is the foundation for board variants — e.g. a boss stage that changes the
board size — without touching the rules engine.

## Verification
- Behaviour-preserving for the classic game.
- +5 tests -> **29/29 pass**, `flutter analyze` clean, Android builds.

Base: `dev`.
