### PR TITLE
refactor(ai/utils): remove dead code (stage 5)

### DIFF
--- a/lib/app/modules/match/controllers/ai_controller.dart
+++ b/lib/app/modules/match/controllers/ai_controller.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:math';
 
 import 'package:get/get.dart';
@@ -15,8 +14,6 @@ class AiController extends GetxController {
   static const String DOC_URL =
       '/forms/d/e/1FAIpQLSf99qDW5LEo3xsWQeQo20MIw0XBAuLf4taufSMkMyUWoWCpJg';
   static const String POST_URL = '/formResponse';
-  static const String QUERY_URL =
-      '/spreadsheets/d/1oaRkah35SbiQ6kNWfQLNQEOLCHFIDHxVxdcxaaMWpz4/gviz/tq';
   static const String usp = 'usp';
   static const String ppurl = 'pp_url';
   static const String boardEntry = 'entry.1551786230';
@@ -169,98 +166,7 @@ class AiController extends GetxController {
       }
     }
 
-    if (!(await isConnected())) {
-      print('Playing without internet...');
-      return makeLocalDecision(gameState);
-    }
-
-    String stateKey = gameState.toString();
-
     return makeLocalDecision(gameState);
-    List<String> remotePlaysResponse = await fetchRemotePlays(stateKey);
-    if (isNewState(remotePlaysResponse)) {
-      print('Playing locally...');
-      Move move = makeLocalDecision(gameState);
-      // print(move);
-      return move;
-    }
-    if (gamemode == gameMode.training && getRandomInt(5) == 0) {
-      print('Forcing locally by luck');
-      return makeLocalDecision(gameState);
-      // print(move);
-    } else {
-      print('Playing remotely...');
-      return getRemotePlay(remotePlaysResponse, gameState);
-      // print(move);
-    }
-  }
-
-  isNewState(List<String> remotePlays) {
-    return remotePlays.isEmpty;
-  }
-
-  Future<List<String>> fetchRemotePlays(String stateKey) async {
-    List<String> remotePlays = [];
-    var uri = Uri.https(docsDomain, QUERY_URL, {
-      'tq': 'select C where B = \'$stateKey\' and D = 1',
-    });
-    // print('\nuri');
-    // print(uri);
-    http.Response response;
-    try {
-      response = await http.get(uri).timeout(const Duration(seconds: 1));
-      print('time limit reached');
-    } catch (e) {
-      print('Network error. playing random');
-      return remotePlays;
-    }
-    if (response.statusCode != 200) {
-      print('Response Status code error: ${response.statusCode}');
-      return remotePlays;
-    }
-    RegExp exp = RegExp(
-      r"(^\/\*O_o\*\/([\s\S]*[\n\r]*)google\.visualization\.Query\.setResponse\(|\);$)",
-    );
-    String ans = response.body.replaceAll(exp, '');
-    if (ans.isEmpty) {
-      return remotePlays;
-    }
-
-    Map<String, dynamic> map = jsonDecode(response.body.replaceAll(exp, ''));
-    if (map['table']?['rows']?.length <= 0) {
-      return remotePlays;
-    }
-    map['table']['rows'].forEach((c) {
-      remotePlays.add(c['c'][0]['v'].toString());
-    });
-    return remotePlays;
-  }
-
-  Move getRemotePlay(List<String> remotePlaysReponse, GameState gs) {
-    List<Move> remoteMoves = remotePlaysReponse.map((resp) {
-      var spliced = resp.split('|');
-      if (isInt(spliced[0])) {
-        return Move(gs.board[int.parse(spliced[1])][int.parse(spliced[0])],
-            gs.board[int.parse(spliced[3])][int.parse(spliced[2])]);
-      }
-      chrt char = getCharFromInitials(spliced[0]);
-      Tile initialTile = gs.myGraveyard.firstWhere((t) => t.char == char);
-      Tile finalTile = gs.board[int.parse(spliced[3])][int.parse(spliced[2])];
-      return Move(initialTile, finalTile);
-    }).toList();
-    // print(remoteMoves);
-    return getRandomObject(remoteMoves);
-  }
-
-  chrt getCharFromInitials(String initials) {
-    return chrt.values.firstWhere((element) => element.name == initials);
-  }
-
-  bool isInt(String? s) {
-    if (s == null) {
-      return false;
-    }
-    return int.tryParse(s) != null;
   }
 
   Move makeLocalDecision(GameState gameState, [bool hard = false]) {

--- a/lib/app/utils/utils.dart
+++ b/lib/app/utils/utils.dart
@@ -227,61 +227,6 @@ getRandomIntBetween(int min, int max) {
   return min + rnd.nextInt(max - min);
 }
 
-void printMatrix(var matrix) {
-  print('matrix:');
-  for (var row in matrix) {
-    String sRow = '';
-    for (var v in row) {
-      String s = v.char == ''
-          ? "\x1B[32m${v.isOption}\x1B[0m"
-          : "\x1B[36m${v.isOption}\x1B[0m";
-      sRow = sRow + s;
-    }
-    print(sRow);
-  }
-}
-
-int getNumberOfIsland(var matrix) {
-  int numberOfIslands = 0;
-
-  var booleanMatrix = List.generate(
-    matrix.length,
-    (i) => List.generate(matrix.length, (i) => 0),
-  );
-  for (int j = 0; j < matrix.length; j++) {
-    for (int i = 0; i < matrix[j].length; i++) {
-      if (matrix[j][i] == 1 && booleanMatrix[j][i] == 0) {
-        //new island
-        numberOfIslands++;
-        booleanMatrix = setIslandInTrue(i, j, booleanMatrix, matrix);
-      }
-    }
-  }
-  print('number of islands: ' + numberOfIslands.toString());
-  return numberOfIslands;
-}
-
-setIslandInTrue(i, j, matrix, orgMatrix) {
-  matrix[j][i] = 1;
-  if (i + 1 < matrix.length &&
-      matrix[j][i + 1] != 1 &&
-      orgMatrix[j][i + 1] == 1) {
-    matrix = setIslandInTrue(i + 1, j, matrix, orgMatrix);
-  }
-  if (i - 1 >= 0 && matrix[j][i - 1] != 1 && orgMatrix[j][i - 1] == 1) {
-    matrix = setIslandInTrue(i - 1, j, matrix, orgMatrix);
-  }
-  if (j + 1 < matrix[i].length &&
-      matrix[j + 1][i] != 1 &&
-      orgMatrix[j + 1][i] == 1) {
-    matrix = setIslandInTrue(i, j + 1, matrix, orgMatrix);
-  }
-  if (j - 1 >= 0 && matrix[j - 1][i] != 1 && orgMatrix[j - 1][i] == 1) {
-    matrix = setIslandInTrue(i, j - 1, matrix, orgMatrix);
-  }
-  return matrix;
-}
-
 Future<bool> isConnected() async {
   var connectivityResult = await (Connectivity().checkConnectivity());
   return connectivityResult.contains(ConnectivityResult.mobile)  ||


### PR DESCRIPTION
## What (Stage 5 — final cleanup of the engine refactor)
Remove dead code surfaced during the refactor. **No behaviour change.**

### ai_controller
The Google-Sheets remote-play path was already dead: `getPlay` returned early
(`return makeLocalDecision(...)`) before any of it ran. Removed:
- the unreachable block in `getPlay` (and the redundant `isConnected` check that
  returned the same thing either way),
- `fetchRemotePlays`, `getRemotePlay`, `isNewState`, `getCharFromInitials`, `isInt`,
- the now-unused `dart:convert` import and `QUERY_URL` constant.

`storeMovemntHistory` (the Forms logging, still called from MatchController) is kept.

### utils
- Removed unused `printMatrix` and the orphan island-counting helpers
  (`getNumberOfIsland`, `setIslandInTrue`).

## Verification
- `flutter analyze` clean (no more `dead_code`), **29/29 tests pass**, Android builds.

## Deliberately deferred
Broad identifier renames (`rock`->`rook`, `Movment`->`Movement`, `oponent`, ...) —
invasive across the enum/asset layer for little functional gain. Can be a separate
mechanical PR later if desired.

Base: `dev`.
