### PR TITLE
feat(juice): capture flash, pulses, haptics & confetti

### DIFF
--- a/lib/app/modules/match/controllers/match_controller.dart
+++ b/lib/app/modules/match/controllers/match_controller.dart
@@ -15,6 +15,7 @@ import '../../../services/database.dart';
 import '../../../utils/gameObjects/gameState.dart';
 import '../../../utils/gameObjects/move.dart';
 import '../../../utils/gameObjects/tile.dart';
+import '../../../utils/juice.dart';
 import '../../../utils/utils.dart';
 import '../../home/controllers/home_controller.dart';
 import '../../language/controllers/language_controller.dart';
@@ -252,6 +253,7 @@ class MatchController extends GetxController with WidgetsBindingObserver {
       if (tile.char != chrt.empty && tile.owner == possession.mine) {
         tile.isSelected = true;
         selectedTile.value = tile;
+        Juice.select();
         // print('selectedTile: $selectedTile');
         highlightAvailableOptions();
       }
@@ -261,9 +263,11 @@ class MatchController extends GetxController with WidgetsBindingObserver {
         recordHistory(tile);
         setTimersAndPlayers();
         Move move = Move(selectedTile.value!, tile);
+        final bool isCapture = tile.char != chrt.empty;
         if (homeController.withSound.value) {
           moveAudioPLayer.play(AssetSource('sounds/wind.mp3'), volume: 0.5);
         }
+        if (!isCapture) Juice.move();
         await animateTiles(move);
         if (checkIfWin(move)) {
           gameOver(playersTurn);
@@ -294,6 +298,8 @@ class MatchController extends GetxController with WidgetsBindingObserver {
       int length = gyController.getGraveyard(playersTurn).length;
       TileController takenTileController =
           Get.find<TileController>(tag: move.finalTile.toString());
+      takenTileController.flash();
+      Juice.capture();
       takenTileController.animateTile(
           move.finalTile.i!, -1 - move.finalTile.j!, null, null, length);
       gyController.animateGraveyard();
@@ -362,6 +368,7 @@ class MatchController extends GetxController with WidgetsBindingObserver {
   void gameOver(player p) async {
     winner = p;
     isGameOver.value = true;
+    Juice.gameOver();
     blackClockState.stopTimer();
     whiteClockState.stopTimer();
     if (p == player.white) {

--- a/lib/app/modules/match/controllers/tile_controller.dart
+++ b/lib/app/modules/match/controllers/tile_controller.dart
@@ -8,8 +8,11 @@ import '../../../data/enums.dart';
 import 'match_controller.dart';
 
 class TileController extends GetxController
-    with GetSingleTickerProviderStateMixin {
+    with GetTickerProviderStateMixin {
   late AnimationController animationController;
+
+  /// Quick gold flash played on the tile when its piece is captured.
+  late AnimationController flashController;
   late MatchController matchController;
   Vector3 translation = Vector3.zero();
   double iScale = 1;
@@ -45,6 +48,11 @@ class TileController extends GetxController
     animationController.reset();
   }
 
+  /// Trigger the capture flash on this tile.
+  void flash() {
+    flashController.forward(from: 0);
+  }
+
   @override
   void onInit() {
     super.onInit();
@@ -52,6 +60,10 @@ class TileController extends GetxController
     animationController = AnimationController(
       vsync: this,
       duration: Duration(milliseconds: matchController.gamemode == gameMode.training ? 100 : 800),
+    );
+    flashController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 380),
     );
   }
 

--- a/lib/app/modules/match/views/gameover_view.dart
+++ b/lib/app/modules/match/views/gameover_view.dart
@@ -6,6 +6,7 @@ import '../../../utils/utils.dart';
 import '../../language/controllers/language_controller.dart';
 import '../controllers/match_controller.dart';
 import '../../../data/enums.dart';
+import '../widgets/confetti_burst.dart';
 
 class GameoverView extends GetView<MatchController> {
   GameoverView({Key? key}) : super(key: key);
@@ -18,112 +19,119 @@ class GameoverView extends GetView<MatchController> {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      height: double.infinity,
-      color:
-          controller.winner == player.white ? Colors.white70 : Colors.black87,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Text(
-              '${l.g('Winner')} ${controller.winner == player.white ? l.g('Sun') : l.g('Moon')}',
-              style: TextStyle(
-                  color: getTextColor(),
-                  fontSize: 48,
-                  fontWeight: FontWeight.bold)),
-          SizedBox(
-              width: 250,
-              height: 250,
-              child: getCharAsset(chrt.queen, controller.winner, true)),
-          if (controller.gamemode == gameMode.solo ||
-              controller.gamemode == gameMode.vs)
-            SizedBox(
-              height: 120,
-              width: 120,
-              child: Column(
-                children: [
-                  SizedBox(
-                    height: 60,
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                      children: [
-                        getCharAsset(chrt.queen, player.white, false),
-                        getCharAsset(chrt.queen, player.black, false)
-                      ],
-                    ),
-                  ),
-                  Text(
-                    '${controller.wScore.value} - ${controller.bScore.value}',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                        color: getTextColor(),
-                        fontSize: 42,
-                        fontWeight: FontWeight.bold),
-                  ),
-                ],
-              ),
-            ),
-          Container(
-            width: 350,
-            decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(10),
-              border: Border.all(color: getTextColor(), width: 2),
-            ),
-            margin: const EdgeInsets.symmetric(vertical: 20),
-            padding: const EdgeInsets.all(10),
-            child: Text(controller.getRandomGameOverScreenText(),
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                    fontWeight: FontWeight.w500,
-                    fontSize: 16,
-                    color: getTextColor())),
-          ),
-          if (controller.gamemode != gameMode.online)
-            SizedBox(
-              height: 40,
-              width: 150,
-              child: ElevatedButton(
-                onPressed: () {
-                  playButtonSound();
-                  controller.restartGame();
-                },
-                child: Text(l.g('Restart')),
-              ),
-            ),
-          if (controller.gamemode == gameMode.online)
-            SizedBox(
-              height: 40,
-              width: 150,
-              child: ElevatedButton(
-                onPressed: () {
-                  playButtonSound();
-                  controller.closeTheGame();
-                },
-                child: Text(l.g('Close')),
-              ),
-            ),
-          if (controller.gamemode == gameMode.online)
-            Obx(() {
-              return SizedBox(
-                  height: 100,
-                  width: 170,
-                  child: Center(
-                    child: Text(
-                        '${l.g('YourScore')}'
-                        '${controller.myLocalScore.value}'
-                        '${controller.isWinner.value! ? '+' : '-'}'
-                        '${controller.scoreChange.value}',
+    return Stack(
+      children: [
+        Container(
+          width: double.infinity,
+          height: double.infinity,
+          color: controller.winner == player.white
+              ? Colors.white70
+              : Colors.black87,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                  '${l.g('Winner')} ${controller.winner == player.white ? l.g('Sun') : l.g('Moon')}',
+                  style: TextStyle(
+                      color: getTextColor(),
+                      fontSize: 48,
+                      fontWeight: FontWeight.bold)),
+              SizedBox(
+                  width: 250,
+                  height: 250,
+                  child: getCharAsset(chrt.queen, controller.winner, true)),
+              if (controller.gamemode == gameMode.solo ||
+                  controller.gamemode == gameMode.vs)
+                SizedBox(
+                  height: 120,
+                  width: 120,
+                  child: Column(
+                    children: [
+                      SizedBox(
+                        height: 60,
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                          children: [
+                            getCharAsset(chrt.queen, player.white, false),
+                            getCharAsset(chrt.queen, player.black, false)
+                          ],
+                        ),
+                      ),
+                      Text(
+                        '${controller.wScore.value} - ${controller.bScore.value}',
+                        textAlign: TextAlign.center,
                         style: TextStyle(
                             color: getTextColor(),
-                            fontSize: 28,
-                            fontWeight: FontWeight.bold)),
-                  ));
-            }),
-          Text('GameId: ${DateTime.now().millisecondsSinceEpoch.toString()}',
-              style: TextStyle(color: getTextColor(), fontSize: 12)),
-        ],
-      ),
+                            fontSize: 42,
+                            fontWeight: FontWeight.bold),
+                      ),
+                    ],
+                  ),
+                ),
+              Container(
+                width: 350,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(color: getTextColor(), width: 2),
+                ),
+                margin: const EdgeInsets.symmetric(vertical: 20),
+                padding: const EdgeInsets.all(10),
+                child: Text(controller.getRandomGameOverScreenText(),
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                        fontWeight: FontWeight.w500,
+                        fontSize: 16,
+                        color: getTextColor())),
+              ),
+              if (controller.gamemode != gameMode.online)
+                SizedBox(
+                  height: 40,
+                  width: 150,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      playButtonSound();
+                      controller.restartGame();
+                    },
+                    child: Text(l.g('Restart')),
+                  ),
+                ),
+              if (controller.gamemode == gameMode.online)
+                SizedBox(
+                  height: 40,
+                  width: 150,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      playButtonSound();
+                      controller.closeTheGame();
+                    },
+                    child: Text(l.g('Close')),
+                  ),
+                ),
+              if (controller.gamemode == gameMode.online)
+                Obx(() {
+                  return SizedBox(
+                      height: 100,
+                      width: 170,
+                      child: Center(
+                        child: Text(
+                            '${l.g('YourScore')}'
+                            '${controller.myLocalScore.value}'
+                            '${controller.isWinner.value! ? '+' : '-'}'
+                            '${controller.scoreChange.value}',
+                            style: TextStyle(
+                                color: getTextColor(),
+                                fontSize: 28,
+                                fontWeight: FontWeight.bold)),
+                      ));
+                }),
+              Text(
+                  'GameId: ${DateTime.now().millisecondsSinceEpoch.toString()}',
+                  style: TextStyle(color: getTextColor(), fontSize: 12)),
+            ],
+          ),
+        ),
+        Positioned.fill(child: ConfettiBurst()),
+      ],
     );
   }
 }

--- a/lib/app/modules/match/widgets/ChessTile.dart
+++ b/lib/app/modules/match/widgets/ChessTile.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:inti_the_inka_chess_game/app/modules/match/views/match_view.dart';
@@ -9,6 +11,7 @@ import 'package:vector_math/vector_math_64.dart' as math;
 
 import '../controllers/tile_controller.dart';
 import '../views/clock_view.dart';
+import 'pulse.dart';
 
 class ChessTile extends GetView {
   ChessTile({Key? key, required this.tile, this.playersTurn}) : super(key: key);
@@ -37,7 +40,7 @@ class ChessTile extends GetView {
   }
 
   player getPlayer() {
-    if (getbool(tile.owner == possession.mine)){
+    if (getbool(tile.owner == possession.mine)) {
       return player.white;
     }
     return player.black;
@@ -48,86 +51,141 @@ class ChessTile extends GetView {
     return SizedBox(
       width: 100,
       height: 100,
-      child: InkWell(
-        onTap: () => matchController.onTapTile(tile),
-        child: RotatedBox(
-          quarterTurns: tile.owner == possession.mine ? 0 : 2,
-          child: Container(
-            decoration: BoxDecoration(
-              image: tile.isOption
-                  ? const DecorationImage(
-                      image: AssetImage('assets/images/selected.png'),
-                    )
-                  : null,
-            ),
-            child: AnimatedBuilder(
-              animation: tileController.animationController,
-              child: Stack(
-                children: [
-                  Center(
-                    child: SizedBox(
-                      width: 80,
-                      height: 80,
-                      child: getBase(
-                        tile.owner == possession.none ? player.none :
-                          getbool(tile.owner == possession.mine)
-                              ? player.white
-                              : player.black,
-                          tile.isSelected),
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          InkWell(
+            onTap: () => matchController.onTapTile(tile),
+            child: RotatedBox(
+              quarterTurns: tile.owner == possession.mine ? 0 : 2,
+              child: AnimatedBuilder(
+                animation: tileController.animationController,
+                child: Stack(
+                  children: [
+                    Center(
+                      child: SizedBox(
+                        width: 80,
+                        height: 80,
+                        child: getBase(
+                            tile.owner == possession.none
+                                ? player.none
+                                : getbool(tile.owner == possession.mine)
+                                    ? player.white
+                                    : player.black,
+                            tile.isSelected),
+                      ),
                     ),
-                  ),
-                  Center(
-                    child: SizedBox(
-                      width: 75,
-                      height: 75,
-                      child: Stack(
-                        children: [
+                    Center(
+                      child: SizedBox(
+                        width: 75,
+                        height: 75,
+                        child: _maybePulse(
+                          tile.isSelected,
                           getCharAsset(
                               tile.char,
                               getbool(tile.owner == possession.mine)
                                   ? player.white
                                   : player.black,
                               tile.isSelected),
-                          // if (tile.char == chrt.king)
-                          // Positioned.fill(
-                          //   top:8,
-                          //     child: Transform.scale(
-                          //         scale: 0.6,
-                          //         child: ClockView(getPlayer())))
-                        ],
+                        ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
+                builder: (BuildContext context, Widget? child) {
+                  return Transform(
+                    origin: const Offset(50, 50),
+                    transform: Matrix4.compose(
+                      tileController.translation *
+                          tileController.animationController
+                              .drive(CurveTween(curve: Curves.easeInOutQuint))
+                              .value,
+                      math.Quaternion.euler(
+                          0,
+                          0,
+                          tileController.rotation *
+                              tileController.animationController
+                                  .drive(
+                                      CurveTween(curve: Curves.easeInOutQuint))
+                                  .value),
+                      math.Vector3.all(tileController.iScale +
+                          (tileController.fScale - tileController.iScale) *
+                              tileController.animationController
+                                  .drive(
+                                      CurveTween(curve: Curves.easeInOutQuint))
+                                  .value),
+                    ),
+                    child: child,
+                  );
+                },
               ),
-              builder: (BuildContext context, Widget? child) {
-                return Transform(
-                  origin: const Offset(50, 50),
-                  transform: Matrix4.compose(
-                    tileController.translation *
-                        tileController.animationController
-                            .drive(CurveTween(curve: Curves.easeInOutQuint))
-                            .value,
-                    math.Quaternion.euler(
-                        0,
-                        0,
-                        tileController.rotation *
-                            tileController.animationController
-                                .drive(CurveTween(curve: Curves.easeInOutQuint))
-                                .value),
-                    math.Vector3.all(tileController.iScale +
-                        (tileController.fScale - tileController.iScale) *
-                            tileController.animationController
-                                .drive(CurveTween(curve: Curves.easeInOutQuint))
-                                .value),
-                  ),
-                  child: child,
-                );
-              },
             ),
           ),
-        ),
+          if (tile.isOption) _optionHint(),
+          _flashOverlay(),
+        ],
       ),
     );
   }
+
+  Widget _maybePulse(bool active, Widget child) =>
+      active ? Pulse(child: child) : child;
+
+  // A pulsing hint on a reachable tile: a hollow ring around a capturable
+  // piece, or a small dot on an empty square.
+  Widget _optionHint() {
+    final bool isCapture = tile.char != chrt.empty;
+    return IgnorePointer(
+      child: Pulse(
+        min: 0.85,
+        max: 1.05,
+        child: isCapture
+            ? Container(
+                width: 78,
+                height: 78,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                      color: Colors.amberAccent.withOpacity(0.85), width: 3),
+                ),
+              )
+            : Container(
+                width: 26,
+                height: 26,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: Colors.white.withOpacity(0.4),
+                ),
+              ),
+      ),
+    );
+  }
+
+  // Gold flash that fades in/out when this tile's piece is captured.
+  Widget _flashOverlay() => IgnorePointer(
+        child: AnimatedBuilder(
+          animation: tileController.flashController,
+          builder: (BuildContext context, Widget? _) {
+            final double v = tileController.flashController.value;
+            if (v == 0) return const SizedBox.shrink();
+            final double opacity = (sin(v * pi) * 0.8).clamp(0.0, 1.0);
+            return Container(
+              width: 90,
+              height: 90,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: const Color(0xFFFFD54F).withOpacity(opacity),
+                boxShadow: [
+                  BoxShadow(
+                    color: const Color(0xFFFFCA28)
+                        .withOpacity((opacity * 0.8).clamp(0.0, 1.0)),
+                    blurRadius: 24,
+                    spreadRadius: 8,
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      );
 }

--- a/lib/app/modules/match/widgets/confetti_burst.dart
+++ b/lib/app/modules/match/widgets/confetti_burst.dart
@@ -1,0 +1,129 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+/// A self-contained confetti rain (no external package). Drop it on top of a
+/// screen inside a Stack; it plays once and then sits idle.
+class ConfettiBurst extends StatefulWidget {
+  const ConfettiBurst({
+    Key? key,
+    this.count = 90,
+    this.duration = const Duration(seconds: 3),
+    this.colors = const [
+      Color(0xFFCCAC4B), // sun gold
+      Color(0xFFEE6136), // moon orange
+      Colors.white,
+      Color(0xFF6CB9F1), // sky blue
+      Colors.redAccent,
+    ],
+  }) : super(key: key);
+
+  final int count;
+  final Duration duration;
+  final List<Color> colors;
+
+  @override
+  State<ConfettiBurst> createState() => _ConfettiBurstState();
+}
+
+class _ConfettiBurstState extends State<ConfettiBurst>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller =
+      AnimationController(vsync: this, duration: widget.duration)..forward();
+  late final List<_Particle> _particles;
+
+  @override
+  void initState() {
+    super.initState();
+    final rnd = Random();
+    _particles = List.generate(widget.count, (_) {
+      return _Particle(
+        startX: rnd.nextDouble(),
+        startY: -0.1 - rnd.nextDouble() * 0.3,
+        driftX: (rnd.nextDouble() - 0.5) * 0.5,
+        fallSpeed: 0.7 + rnd.nextDouble() * 0.8,
+        size: 6 + rnd.nextDouble() * 9,
+        color: widget.colors[rnd.nextInt(widget.colors.length)],
+        rotation: rnd.nextDouble() * pi * 2,
+        spin: (rnd.nextDouble() - 0.5) * 8,
+        delay: rnd.nextDouble() * 0.25,
+      );
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (_, __) => CustomPaint(
+          size: Size.infinite,
+          painter: _ConfettiPainter(_particles, _controller.value),
+        ),
+      ),
+    );
+  }
+}
+
+class _Particle {
+  _Particle({
+    required this.startX,
+    required this.startY,
+    required this.driftX,
+    required this.fallSpeed,
+    required this.size,
+    required this.color,
+    required this.rotation,
+    required this.spin,
+    required this.delay,
+  });
+
+  final double startX; // 0..1 of width
+  final double startY; // fraction of height (can be negative = above screen)
+  final double driftX; // horizontal drift in fractions of width
+  final double fallSpeed; // fractions of height per unit time
+  final double size;
+  final Color color;
+  final double rotation;
+  final double spin;
+  final double delay; // 0..1, when this particle starts falling
+}
+
+class _ConfettiPainter extends CustomPainter {
+  _ConfettiPainter(this.particles, this.t);
+
+  final List<_Particle> particles;
+  final double t;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint();
+    for (final p in particles) {
+      final local = ((t - p.delay) / (1 - p.delay)).clamp(0.0, 1.0);
+      if (local <= 0) continue;
+      final x = (p.startX + p.driftX * local) * size.width +
+          sin(local * pi * 4 + p.rotation) * 6;
+      final y = (p.startY + p.fallSpeed * local) * size.height;
+      if (y > size.height) continue;
+      paint.color = p.color.withOpacity((1 - local).clamp(0.0, 1.0));
+      canvas.save();
+      canvas.translate(x, y);
+      canvas.rotate(p.rotation + p.spin * local);
+      canvas.drawRect(
+        Rect.fromCenter(
+            center: Offset.zero, width: p.size, height: p.size * 0.5),
+        paint,
+      );
+      canvas.restore();
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _ConfettiPainter old) => old.t != t;
+}

--- a/lib/app/modules/match/widgets/pulse.dart
+++ b/lib/app/modules/match/widgets/pulse.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+/// Continuously scales its [child] between [min] and [max]. Used to make the
+/// selected piece and the move hints feel alive.
+class Pulse extends StatefulWidget {
+  const Pulse({
+    Key? key,
+    required this.child,
+    this.min = 1.0,
+    this.max = 1.08,
+    this.duration = const Duration(milliseconds: 700),
+  }) : super(key: key);
+
+  final Widget child;
+  final double min;
+  final double max;
+  final Duration duration;
+
+  @override
+  State<Pulse> createState() => _PulseState();
+}
+
+class _PulseState extends State<Pulse> with SingleTickerProviderStateMixin {
+  late final AnimationController _controller =
+      AnimationController(vsync: this, duration: widget.duration)
+        ..repeat(reverse: true);
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaleTransition(
+      scale: Tween<double>(begin: widget.min, end: widget.max).animate(
+        CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+      ),
+      child: widget.child,
+    );
+  }
+}

--- a/lib/app/utils/juice.dart
+++ b/lib/app/utils/juice.dart
@@ -1,0 +1,40 @@
+import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter/services.dart';
+import 'package:get/get.dart';
+
+import '../modules/home/controllers/home_controller.dart';
+
+/// Small "juice" helpers: one-shot sound effects + haptics for the match.
+///
+/// SFX respect the in-game sound toggle. The capture/victory clips currently
+/// reuse `button.mp3` as placeholders — drop dedicated `assets/sounds/capture.mp3`
+/// and `assets/sounds/victory.mp3` in and swap the asset paths below.
+final AudioPlayer _sfxPlayer = AudioPlayer();
+
+bool get _soundOn => Get.find<HomeController>().withSound.value;
+
+void _sfx(String asset, double volume) {
+  if (_soundOn) {
+    _sfxPlayer.play(AssetSource(asset), volume: volume);
+  }
+}
+
+class Juice {
+  /// Picking up / selecting a piece.
+  static void select() => HapticFeedback.selectionClick();
+
+  /// A normal (non-capturing) move landed.
+  static void move() => HapticFeedback.lightImpact();
+
+  /// A piece was captured.
+  static void capture() {
+    HapticFeedback.mediumImpact();
+    _sfx('sounds/button.mp3', 0.8); // TODO: dedicated capture SFX
+  }
+
+  /// The match ended (someone took the king).
+  static void gameOver() {
+    HapticFeedback.heavyImpact();
+    _sfx('sounds/button.mp3', 1.0); // TODO: dedicated victory sting
+  }
+}


### PR DESCRIPTION
## What — first "juice" pass (visual & tactile polish)
All self-contained, **no new assets** (capture/victory SFX reuse `button.mp3` as
placeholders for now).

### Visuals
- **Selected piece pulses** (gentle breathing scale).
- **Animated move hints**: a small dot on empty squares, a **gold ring** around a
  capturable piece (replaces the static `selected.png` highlight).
- **Capture flash**: the captured tile flashes gold as the piece flies off.
- **Confetti** rains over the win/lose screen (custom `CustomPainter`, no package).

### Tactile / audio
- **Haptics**: selection click on pick-up, light tap on move, medium on capture,
  heavy on game over.
- **Capture & game-over SFX** wired (placeholder = `button.mp3`).

### New files
`utils/juice.dart`, `widgets/pulse.dart`, `widgets/confetti_burst.dart`.

## Heads up
- This is **visual** — needs your eyes on the emulator to tune (pulse amount,
  flash color/intensity, confetti density, haptic strength).
- TODO: drop `assets/sounds/capture.mp3` + `victory.mp3` and swap the placeholders
  in `juice.dart`.

analyze clean, Android builds. Base: `dev`.
