### PR TITLE
docs: add PROJECT.md (workflow + roadmap)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,9 @@
 Minichess game built in **Flutter**, published and **in production** at https://inkachess.com/.
 Repo: `github.com/hotakutsuki/minichess` · package name: `inti_the_inka_chess_game`.
 
+> **Workflow + feature roadmap (bosses, modifiers, story mode, …):** see
+> [`docs/PROJECT.md`](docs/PROJECT.md). This file is the technical/architecture reference.
+
 ## Stack
 - Flutter (Android, iOS, web, desktop targets present)
 - Firebase (Firestore, Functions in `firebasefunctions/`, Hosting)


### PR DESCRIPTION
Adds `docs/PROJECT.md`: in-repo workflow/build conventions + the feature roadmap (tutorial, rule modifiers, story/campaign, bosses incl. board-size-changing boss and a real-checkmate variation), current status and TODOs. Linked from CLAUDE.md. Docs-only. Base: dev.