### PR TITLE
fix(transition): align curtain sun + restore lift animation on close

### DIFF
--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -338,16 +338,20 @@ class HomeView extends GetView<HomeController> with WidgetsBindingObserver {
                   ),
                   width: MediaQuery.of(context).size.width - 10,
                   height: MediaQuery.of(context).size.height - 20,
-                  child: Center(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        SizedBox(
-                            height: 60,
-                            child:
-                                Image.asset('assets/images/pieces/wkingd.png')),
-                        const SizedBox(height: 24),
-                        Obx(() {
+                  child: Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      // Keep the sun dead-centre so it lines up exactly with the
+                      // match curtain's lit sun (same size + position = no jump
+                      // when switching screens).
+                      SizedBox(
+                          height: 60,
+                          child:
+                              Image.asset('assets/images/pieces/wkingd.png')),
+                      // Precache progress floats below the sun without shifting it.
+                      Align(
+                        alignment: const Alignment(0, 0.25),
+                        child: Obx(() {
                           final p = controller.taleProgress.value;
                           if (p <= 0 || p >= 1) {
                             return const SizedBox.shrink();
@@ -355,6 +359,7 @@ class HomeView extends GetView<HomeController> with WidgetsBindingObserver {
                           return SizedBox(
                             width: 180,
                             child: Column(
+                              mainAxisSize: MainAxisSize.min,
                               children: [
                                 ClipRRect(
                                   borderRadius: BorderRadius.circular(8),
@@ -375,8 +380,8 @@ class HomeView extends GetView<HomeController> with WidgetsBindingObserver {
                             ),
                           );
                         }),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
                 ),
               ),

--- a/lib/app/modules/match/controllers/match_controller.dart
+++ b/lib/app/modules/match/controllers/match_controller.dart
@@ -473,6 +473,14 @@ class MatchController extends GetxController with WidgetsBindingObserver {
       dbController.closeMatch();
     }
     Get.offAndToNamed(Routes.HOME);
+    // setMode() left the menu curtain down underneath the match. Let the home
+    // screen mount with that curtain still covering it, then lift it so the menu
+    // is revealed with the same slide-up animation used when entering a match
+    // (setting it false immediately skips the animation and the curtain just
+    // vanishes). The lift itself uses the same 500ms easeOutExpo as every other
+    // curtain; this pause just lets it rest a beat before rising, like on entry.
+    await Future.delayed(const Duration(milliseconds: 500));
+    homeController.isLoading.value = false;
   }
 
   initBoardState() {

--- a/lib/app/modules/match/views/match_view.dart
+++ b/lib/app/modules/match/views/match_view.dart
@@ -168,7 +168,7 @@ class MatchView extends GetView<MatchController> {
           height: MediaQuery.of(context).size.height - 20,
           child: Center(
               child: SizedBox(
-                  height: 25,
+                  height: 60,
                   child: Image.asset('assets/images/pieces/wkings.png'))),
         ),
       ),


### PR DESCRIPTION
Fixes three issues with the menu↔match curtain transition (the animated panel with the sun that drops in / slides up between the main menu and a game).

## Bugs

1. **Sun sizes mismatched** — the lit sun in the match curtain was `height: 25` while the menu's unlit sun was `60`, so the sun *shrank* as it "lit up", killing the effect. Both are now `60`.
2. **Sun position jumped** — the menu's sun lived inside a `Column` with a spacer + progress bar, pushing it ~12px above centre, while the match sun was perfectly centred. They now centre identically; the precache progress bar floats below the sun (`Align(0, 0.25)`) without shifting it.
3. **Curtain stuck on close** — `setMode()` lowers the menu curtain (`HomeController.isLoading = true`) and intentionally leaves it down under the match. `closeTheGame()` never reset it, so after pressing ✕ the menu curtain stayed down covering the home screen. It's now reset after navigating, with a 500ms rest so the lift plays the same **500ms easeOutExpo** slide-up used by every other curtain.

## Verification
- `flutter analyze` clean (no new issues).
- Tested by eye on the emulator: sun lights up in place (same size + position), curtain slides back up at the same speed as elsewhere when closing a match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)