### PR TITLE
feat(engine): rule-modifier hooks — movement + capture (campaign)

### DIFF
--- a/lib/app/engine/rule_modifier.dart
+++ b/lib/app/engine/rule_modifier.dart
@@ -1,4 +1,6 @@
 import '../data/enums.dart';
+import '../utils/gameObjects/gameState.dart';
+import '../utils/gameObjects/move.dart';
 import 'rules.dart';
 
 /// A rule change carried by a [GameState] and applied at defined engine hook
@@ -11,9 +13,16 @@ import 'rules.dart';
 /// must be immutable: a [GameState] is cloned constantly by the AI look-ahead
 /// and only the reference to the modifier list is copied.
 ///
-/// PR 1 ships only the movement hook ([transformOffsets]); later hooks (capture
-/// resolution, per-turn ticks, win condition) will be added as more methods
-/// here, each defaulting to a no-op so existing modifiers keep compiling.
+/// PR 1 shipped the movement hook ([transformOffsets]); PR 2 adds the capture
+/// hooks ([returnsCapturedToOwner], [extraCaptures]). Later hooks (per-turn
+/// ticks, win condition) will be added the same way — each defaulting to a
+/// no-op so existing modifiers keep compiling.
+///
+/// SIDE CAVEAT: at capture time the mover is always [possession.mine] (the board
+/// rotates each turn), so for the capture hooks [side] is frame-relative ("the
+/// side to move"), not a stable player/boss identity. Durable player-vs-boss
+/// targeting is a known follow-up (the [GameState] must carry which frame is the
+/// protagonist's).
 abstract class RuleModifier {
   const RuleModifier();
 
@@ -30,6 +39,17 @@ abstract class RuleModifier {
   List<List<int>> transformOffsets(
           chrt piece, possession owner, List<List<int>> base) =>
       base;
+
+  /// Capture hook — disposition. If true, a piece captured by the current mover
+  /// is **not** claimed by the captor (the vanilla, Shogi-style drop); it
+  /// returns to its original owner instead. The first applicable modifier wins.
+  bool returnsCapturedToOwner() => false;
+
+  /// Capture hook — side effects. Extra board tiles (`[i, j]` pairs) cleared as
+  /// a consequence of a capturing [move] (e.g. the Oso's "Embestida" area hit).
+  /// Off-board or non-enemy tiles in the result are ignored by the engine.
+  /// Default: none.
+  List<List<int>> extraCaptures(Move move, GameState gs) => const [];
 }
 
 /// Joker "doble paso": the affected side's pieces gain a **2-square** option in
@@ -80,5 +100,39 @@ class TransformAllPiecesModifier extends RuleModifier {
     // Resolve the target's offsets for THIS owner so direction-dependent
     // targets (like the knight) still mirror correctly.
     return pieceOffsets(target, owner);
+  }
+}
+
+/// Rule "invertir posesión de captura": captured pieces are never claimed by the
+/// captor — they return to their original owner (no Shogi-style drops from your
+/// own graveyard of the pieces you took).
+class ReturnCapturedModifier extends RuleModifier {
+  const ReturnCapturedModifier({this.side = possession.none});
+
+  @override
+  final possession side;
+
+  @override
+  bool returnsCapturedToOwner() => true;
+}
+
+/// Oso "Embestida" (also a candidate joker): a capturing move also clears the
+/// orthogonally-adjacent enemy pieces around the square the mover lands on.
+class AreaCaptureModifier extends RuleModifier {
+  const AreaCaptureModifier({this.side = possession.none});
+
+  @override
+  final possession side;
+
+  @override
+  List<List<int>> extraCaptures(Move move, GameState gs) {
+    final i = move.finalTile.i!;
+    final j = move.finalTile.j!;
+    return [
+      [i + 1, j],
+      [i - 1, j],
+      [i, j + 1],
+      [i, j - 1],
+    ];
   }
 }

--- a/lib/app/engine/rule_modifier.dart
+++ b/lib/app/engine/rule_modifier.dart
@@ -1,0 +1,84 @@
+import '../data/enums.dart';
+import 'rules.dart';
+
+/// A rule change carried by a [GameState] and applied at defined engine hook
+/// points. Boss powers (campaign) and player jokers are both [RuleModifier]s;
+/// [side] marks who it affects.
+///
+/// Every hook defaults to a no-op, so an **empty modifier list == vanilla
+/// rules** — the engine behaves exactly as before unless a match opts in. This
+/// is the single extension seam the campaign/joker systems build on. Modifiers
+/// must be immutable: a [GameState] is cloned constantly by the AI look-ahead
+/// and only the reference to the modifier list is copied.
+///
+/// PR 1 ships only the movement hook ([transformOffsets]); later hooks (capture
+/// resolution, per-turn ticks, win condition) will be added as more methods
+/// here, each defaulting to a no-op so existing modifiers keep compiling.
+abstract class RuleModifier {
+  const RuleModifier();
+
+  /// Which side the modifier affects. [possession.none] means both sides.
+  possession get side => possession.none;
+
+  bool appliesTo(possession owner) =>
+      side == possession.none || side == owner;
+
+  /// Movement hook. Given a piece's [base] relative offsets (from
+  /// [pieceOffsets]), return the offsets it may actually use. Default: the
+  /// offsets are returned unchanged. Implementations must return a **new** list
+  /// and never mutate [base] (some base tables are `const`).
+  List<List<int>> transformOffsets(
+          chrt piece, possession owner, List<List<int>> base) =>
+      base;
+}
+
+/// Joker "doble paso": the affected side's pieces gain a **2-square** option in
+/// each direction they can already move, on top of their normal 1-square moves.
+///
+/// The board has no path/blocking logic (every base move is a single exact
+/// step), so a 2-step move simply reaches a farther exact square — consistent
+/// with how the engine already models movement.
+class DoubleStepModifier extends RuleModifier {
+  const DoubleStepModifier({this.side = possession.none});
+
+  @override
+  final possession side;
+
+  @override
+  List<List<int>> transformOffsets(
+      chrt piece, possession owner, List<List<int>> base) {
+    if (!appliesTo(owner)) return base;
+    return [
+      ...base,
+      for (final o in base) [o[0] * 2, o[1] * 2],
+    ];
+  }
+}
+
+/// Boss power (Oso, life 2) "todas se vuelven osos": every one of the affected
+/// side's pieces moves like [target] (default the knight/oso), regardless of
+/// what it actually is.
+///
+/// The **king is left untouched** — its move is gated specially by the engine
+/// (king-safety look-ahead) and it is the win target, so transforming it would
+/// change unrelated rules. Empty tiles are likewise ignored (they never move).
+class TransformAllPiecesModifier extends RuleModifier {
+  const TransformAllPiecesModifier(
+      {this.target = chrt.knight, this.side = possession.none});
+
+  final chrt target;
+
+  @override
+  final possession side;
+
+  @override
+  List<List<int>> transformOffsets(
+      chrt piece, possession owner, List<List<int>> base) {
+    if (!appliesTo(owner) || piece == chrt.king || piece == chrt.empty) {
+      return base;
+    }
+    // Resolve the target's offsets for THIS owner so direction-dependent
+    // targets (like the knight) still mirror correctly.
+    return pieceOffsets(target, owner);
+  }
+}

--- a/lib/app/engine/rules.dart
+++ b/lib/app/engine/rules.dart
@@ -2,6 +2,7 @@ import '../data/enums.dart';
 import '../utils/gameObjects/gameState.dart';
 import '../utils/gameObjects/move.dart';
 import '../utils/gameObjects/tile.dart';
+import 'rule_modifier.dart';
 
 /// Pure minichess rules engine.
 ///
@@ -137,10 +138,22 @@ List<List<int>> pieceOffsets(chrt piece, possession owner) {
   }
 }
 
+/// The offsets a piece may actually use, after folding in the [GameState]'s
+/// active [RuleModifier]s. With no modifiers this returns [pieceOffsets]
+/// verbatim, so vanilla matches are unaffected. This is the seam every
+/// movement-changing boss power / joker routes through.
+List<List<int>> effectiveOffsets(chrt piece, possession owner, GameState gs) {
+  var offsets = pieceOffsets(piece, owner);
+  for (final m in gs.modifiers) {
+    offsets = m.transformOffsets(piece, owner, offsets);
+  }
+  return offsets;
+}
+
 bool isValidMovmentPerPiece(Move m, GameState gs, [bool hard = false]) {
   final di = m.finalTile.i! - m.initialTile.i!;
   final dj = m.finalTile.j! - m.initialTile.j!;
-  final reachable = pieceOffsets(m.initialTile.char, m.initialTile.owner)
+  final reachable = effectiveOffsets(m.initialTile.char, m.initialTile.owner, gs)
       .any((o) => o[0] == di && o[1] == dj);
   if (!reachable) return false;
   // The king is the only piece whose move can be rejected — and only when

--- a/lib/app/utils/gameObjects/gameState.dart
+++ b/lib/app/utils/gameObjects/gameState.dart
@@ -5,24 +5,31 @@ import '../../data/enums.dart';
 
 import '../../engine/board_config.dart';
 import '../../engine/board_factory.dart';
+import '../../engine/rule_modifier.dart';
 import '../../engine/rules.dart';
 import 'move.dart';
 
 class GameState {
   GameState(this.board, this.myGraveyard, this.enemyGraveyard,
-      {this.config = BoardConfig.classic});
+      {this.config = BoardConfig.classic, this.modifiers = const []});
 
   GameState.named(
       {board,
       myGraveyard,
       enemyGraveyard,
-      BoardConfig config = BoardConfig.classic})
-      : this(board, myGraveyard, enemyGraveyard, config: config);
+      BoardConfig config = BoardConfig.classic,
+      List<RuleModifier> modifiers = const []})
+      : this(board, myGraveyard, enemyGraveyard,
+            config: config, modifiers: modifiers);
 
   List<List<Tile>> board;
   List<Tile> myGraveyard;
   List<Tile> enemyGraveyard;
   final BoardConfig config;
+
+  /// Active rule changes (boss powers / jokers). Empty == vanilla rules.
+  /// Modifiers are immutable, so [clone] copies the list reference.
+  final List<RuleModifier> modifiers;
 
   GameState changeGameState(Move move) {
     sendPieceToGrave(move);
@@ -84,6 +91,7 @@ class GameState {
       myGraveyard: [...gs.myGraveyard],
       enemyGraveyard: [...gs.enemyGraveyard],
       config: gs.config,
+      modifiers: gs.modifiers,
     );
   }
 

--- a/lib/app/utils/gameObjects/gameState.dart
+++ b/lib/app/utils/gameObjects/gameState.dart
@@ -32,8 +32,12 @@ class GameState {
   final List<RuleModifier> modifiers;
 
   GameState changeGameState(Move move) {
+    // `move.finalTile` aliases the board tile, which `rewritePosition` overwrites
+    // with the mover — so decide whether this was a capture up front.
+    final wasCapture = move.finalTile.char != chrt.empty;
     sendPieceToGrave(move);
     rewritePosition(move);
+    if (wasCapture) applyExtraCaptures(move);
     return this;
   }
 
@@ -46,8 +50,43 @@ class GameState {
 
   sendPieceToGrave(Move move) {
     if (move.finalTile.char != chrt.empty) {
-      myGraveyard.add(Tile(
-          move.finalTile.char, toggleOwner(move.finalTile.owner), null, null));
+      _sendToGrave(move.finalTile.char, move.finalTile.owner);
+    }
+  }
+
+  // A captured piece normally becomes the captor's (redeployable from its
+  // graveyard, Shogi-style). The "invertir posesión" modifier instead returns
+  // it to its original owner. At this point the captor is always `mine`, so the
+  // captured piece's [owner] is `enemy`.
+  void _sendToGrave(chrt char, possession owner) {
+    final returnToOwner = modifiers
+        .any((m) => m.appliesTo(possession.mine) && m.returnsCapturedToOwner());
+    if (returnToOwner) {
+      enemyGraveyard.add(Tile(char, owner, null, null));
+    } else {
+      myGraveyard.add(Tile(char, toggleOwner(owner), null, null));
+    }
+  }
+
+  // Side-effect captures (e.g. Oso "Embestida"), applied by [changeGameState]
+  // only when the move was a capture, after the mover has been placed. Only
+  // enemy-occupied, on-board tiles are affected.
+  void applyExtraCaptures(Move move) {
+    for (final m in modifiers) {
+      if (!m.appliesTo(possession.mine)) continue;
+      for (final c in m.extraCaptures(move, this)) {
+        final i = c[0];
+        final j = c[1];
+        if (j < 0 || j >= board.length || i < 0 || i >= board[j].length) {
+          continue;
+        }
+        final t = board[j][i];
+        if (t.owner == possession.enemy && t.char != chrt.empty) {
+          _sendToGrave(t.char, t.owner);
+          t.char = chrt.empty;
+          t.owner = possession.none;
+        }
+      }
     }
   }
 

--- a/test/engine/rule_modifier_test.dart
+++ b/test/engine/rule_modifier_test.dart
@@ -14,11 +14,16 @@ import 'package:inti_the_inka_chess_game/app/utils/gameObjects/tile.dart';
 List<List<Tile>> _emptyBoard() => List.generate(
     4, (j) => List.generate(3, (i) => Tile(chrt.empty, possession.none, i, j)));
 
-GameState _stateWith(List<RuleModifier> modifiers) => GameState.named(
-    board: _emptyBoard(),
-    myGraveyard: <Tile>[],
-    enemyGraveyard: <Tile>[],
-    modifiers: modifiers);
+GameState _stateWith(List<RuleModifier> modifiers) =>
+    _boardStateWith(_emptyBoard(), modifiers);
+
+GameState _boardStateWith(
+        List<List<Tile>> board, List<RuleModifier> modifiers) =>
+    GameState.named(
+        board: board,
+        myGraveyard: <Tile>[],
+        enemyGraveyard: <Tile>[],
+        modifiers: modifiers);
 
 Move _move(chrt c, possession o, int i0, int j0, int i1, int j1) =>
     Move(Tile(c, o, i0, j0), Tile(chrt.empty, possession.none, i1, j1));
@@ -90,6 +95,63 @@ void main() {
     test('the enemy side is untouched (side=mine)', () {
       expect(effectiveOffsets(chrt.bishop, possession.enemy, gs),
           pieceOffsets(chrt.bishop, possession.enemy));
+    });
+  });
+
+  group('ReturnCapturedModifier (invert possession of capture)', () {
+    // A mine rock at (0,0) captures an enemy pawn at (0,1).
+    List<List<Tile>> board() {
+      final b = _emptyBoard();
+      b[0][0] = Tile(chrt.rock, possession.mine, 0, 0);
+      b[1][0] = Tile(chrt.pawn, possession.enemy, 0, 1);
+      return b;
+    }
+
+    test('vanilla: the captor claims the captured piece', () {
+      final b = board();
+      final gs = _boardStateWith(b, const []);
+      gs.changeGameState(Move(b[0][0], b[1][0]));
+      expect(gs.myGraveyard.length, 1);
+      expect(gs.myGraveyard.first.char, chrt.pawn);
+      expect(gs.myGraveyard.first.owner, possession.mine);
+      expect(gs.enemyGraveyard, isEmpty);
+    });
+
+    test('modifier: the captured piece returns to its owner', () {
+      final b = board();
+      final gs = _boardStateWith(b, const [ReturnCapturedModifier()]);
+      gs.changeGameState(Move(b[0][0], b[1][0]));
+      expect(gs.myGraveyard, isEmpty);
+      expect(gs.enemyGraveyard.length, 1);
+      expect(gs.enemyGraveyard.first.char, chrt.pawn);
+      expect(gs.enemyGraveyard.first.owner, possession.enemy);
+    });
+  });
+
+  group('AreaCaptureModifier (Embestida)', () {
+    test('a capture also clears an orthogonally-adjacent enemy piece', () {
+      final b = _emptyBoard();
+      b[0][0] = Tile(chrt.rock, possession.mine, 0, 0); // mover
+      b[1][0] = Tile(chrt.pawn, possession.enemy, 0, 1); // captured (landing)
+      b[1][1] = Tile(chrt.bishop, possession.enemy, 1, 1); // adjacent -> cleared
+      b[3][2] = Tile(chrt.rock, possession.enemy, 2, 3); // far -> untouched
+      final gs = _boardStateWith(b, const [AreaCaptureModifier()]);
+      gs.changeGameState(Move(b[0][0], b[1][0]));
+      expect(b[1][1].char, chrt.empty); // adjacent enemy gone
+      expect(b[1][1].owner, possession.none);
+      expect(b[3][2].char, chrt.rock); // far enemy stays
+      // captor's graveyard holds both the landed capture and the area hit.
+      expect(gs.myGraveyard.length, 2);
+    });
+
+    test('no area effect when the move does not capture', () {
+      final b = _emptyBoard();
+      b[0][0] = Tile(chrt.rock, possession.mine, 0, 0);
+      b[1][1] = Tile(chrt.bishop, possession.enemy, 1, 1); // adjacent to empty landing
+      final gs = _boardStateWith(b, const [AreaCaptureModifier()]);
+      gs.changeGameState(Move(b[0][0], b[1][0])); // lands on empty (0,1)
+      expect(b[1][1].char, chrt.bishop); // untouched: no capture happened
+      expect(gs.myGraveyard, isEmpty);
     });
   });
 }

--- a/test/engine/rule_modifier_test.dart
+++ b/test/engine/rule_modifier_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:inti_the_inka_chess_game/app/data/enums.dart';
+import 'package:inti_the_inka_chess_game/app/engine/rule_modifier.dart';
+import 'package:inti_the_inka_chess_game/app/engine/rules.dart';
+import 'package:inti_the_inka_chess_game/app/utils/gameObjects/gameState.dart';
+import 'package:inti_the_inka_chess_game/app/utils/gameObjects/move.dart';
+import 'package:inti_the_inka_chess_game/app/utils/gameObjects/tile.dart';
+
+// Tests for the rule-modifier hook (PR 1: the movement seam).
+//
+// The contract: an empty modifier list leaves the engine byte-for-byte vanilla,
+// and each modifier only bends movement for the side it applies to.
+
+List<List<Tile>> _emptyBoard() => List.generate(
+    4, (j) => List.generate(3, (i) => Tile(chrt.empty, possession.none, i, j)));
+
+GameState _stateWith(List<RuleModifier> modifiers) => GameState.named(
+    board: _emptyBoard(),
+    myGraveyard: <Tile>[],
+    enemyGraveyard: <Tile>[],
+    modifiers: modifiers);
+
+Move _move(chrt c, possession o, int i0, int j0, int i1, int j1) =>
+    Move(Tile(c, o, i0, j0), Tile(chrt.empty, possession.none, i1, j1));
+
+void main() {
+  group('effectiveOffsets with no modifiers', () {
+    test('returns pieceOffsets verbatim (vanilla)', () {
+      final gs = _stateWith(const []);
+      for (final piece in chrt.values) {
+        for (final owner in [possession.mine, possession.enemy]) {
+          expect(effectiveOffsets(piece, owner, gs),
+              pieceOffsets(piece, owner),
+              reason: '$piece/$owner');
+        }
+      }
+    });
+  });
+
+  group('DoubleStepModifier', () {
+    test('adds a 2-square option while keeping the 1-square move', () {
+      final gs = _stateWith(const [DoubleStepModifier()]);
+      // rock: still one step...
+      expect(isValidMovmentPerPiece(
+          _move(chrt.rock, possession.mine, 1, 1, 1, 2), gs, true), isTrue);
+      // ...and now a two-step jump in the same direction.
+      expect(isValidMovmentPerPiece(
+          _move(chrt.rock, possession.mine, 1, 1, 1, 3), gs, true), isTrue);
+    });
+
+    test('does nothing without the modifier', () {
+      final gs = _stateWith(const []);
+      expect(isValidMovmentPerPiece(
+          _move(chrt.rock, possession.mine, 1, 1, 1, 3), gs, true), isFalse);
+    });
+
+    test('side=mine leaves the enemy untouched', () {
+      final gs = _stateWith(const [DoubleStepModifier(side: possession.mine)]);
+      // mine gets the two-step...
+      expect(isValidMovmentPerPiece(
+          _move(chrt.rock, possession.mine, 1, 1, 1, 3), gs, true), isTrue);
+      // ...the enemy does not.
+      expect(isValidMovmentPerPiece(
+          _move(chrt.rock, possession.enemy, 1, 3, 1, 1), gs, true), isFalse);
+    });
+  });
+
+  group('TransformAllPiecesModifier (all become knights/osos)', () {
+    final gs = _stateWith(
+        const [TransformAllPiecesModifier(side: possession.mine)]);
+
+    test('a bishop moves like a knight (straight forward, normally illegal)',
+        () {
+      // Vanilla bishop cannot step straight forward...
+      expect(isValidMovmentPerPiece(
+          _move(chrt.bishop, possession.mine, 1, 1, 1, 2),
+          _stateWith(const []), true), isFalse);
+      // ...but as an oso it can.
+      expect(isValidMovmentPerPiece(
+          _move(chrt.bishop, possession.mine, 1, 1, 1, 2), gs, true), isTrue);
+    });
+
+    test('the king is left untouched', () {
+      // The knight/oso cannot step two-back-diagonally; the king still moves
+      // exactly like a king (one step any direction), unchanged.
+      expect(effectiveOffsets(chrt.king, possession.mine, gs),
+          pieceOffsets(chrt.king, possession.mine));
+    });
+
+    test('the enemy side is untouched (side=mine)', () {
+      expect(effectiveOffsets(chrt.bishop, possession.enemy, gs),
+          pieceOffsets(chrt.bishop, possession.enemy));
+    });
+  });
+}


### PR DESCRIPTION
Foundation of the **campaign / rule-modifier** system (design in project memory). A `RuleModifier` is a data-driven rule change carried by `GameState` and applied at defined engine hook points. **Boss powers** and **player jokers** are both `RuleModifier`s — same pipeline, differing only by `side`. This is what lets us "change the rules in-game" (e.g. a boss reviving with a new power = adding a modifier mid-match).

**Empty modifier list == vanilla rules**, so existing matches are unaffected.

## Hooks in this PR

**1. Movement** (`transformOffsets`) — folded over `pieceOffsets` via new `effectiveOffsets()`; `isValidMovmentPerPiece` routes through it, so **the AI respects modifiers for free**.
- `DoubleStepModifier` (joker): adds a 2-square option per direction.
- `TransformAllPiecesModifier` (Oso boss, life 2): all of a side's pieces move like the oso/knight (king untouched).

**2. Capture resolution** (`returnsCapturedToOwner`, `extraCaptures`) — `changeGameState` routes captures through modifier-aware disposition + side effects.
- `ReturnCapturedModifier` ("invertir posesión"): captured pieces return to their owner instead of being claimed by the captor.
- `AreaCaptureModifier` (Oso "Embestida"): a capture also clears orthogonally-adjacent enemy pieces.
- Fix: `wasCapture` is computed **before** `rewritePosition`, since `move.finalTile` aliases the board tile the rewrite overwrites (otherwise area capture fired on non-capturing moves).

## Scope / safety
Pure engine only — no UI / Firestore / online-flow touched. Well covered by tests.

**Known follow-up:** capture-hook `side` is currently frame-relative (the mover is always `mine` after rotation); durable player-vs-boss targeting needs `GameState` to carry which frame is the protagonist's. Documented in code.

## Verification
- `flutter analyze` — no new issues (only pre-existing `info` lints in `gameState.dart`).
- `flutter test test/engine/` — **40/40 pass** (10 new + all pre-existing characterization tests unchanged).

## Next PRs (sketch)
per-turn ticks (spawn, wither, wind) → win/lives (checkmate, N lives) → setup (felled tiles, 5×4) → campaign/joker meta + UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)