### PR TITLE
feat(engine): per-turn tick hook + spawn/wind modifiers (campaign)

### DIFF
--- a/lib/app/engine/rule_modifier.dart
+++ b/lib/app/engine/rule_modifier.dart
@@ -1,6 +1,7 @@
 import '../data/enums.dart';
 import '../utils/gameObjects/gameState.dart';
 import '../utils/gameObjects/move.dart';
+import '../utils/gameObjects/tile.dart';
 import 'rules.dart';
 
 /// A rule change carried by a [GameState] and applied at defined engine hook
@@ -50,6 +51,14 @@ abstract class RuleModifier {
   /// Off-board or non-enemy tiles in the result are ignored by the engine.
   /// Default: none.
   List<List<int>> extraCaptures(Move move, GameState gs) => const [];
+
+  /// Per-turn hook. Runs once at the start of the side-to-move's turn (the mover
+  /// is [possession.mine] in the current frame), letting a modifier mutate the
+  /// board outside of a normal move — spawn reinforcements, wither idle pieces,
+  /// blow a wind across the board. Default: no-op.
+  ///
+  /// Frame-relative like the capture hooks (see the SIDE CAVEAT above).
+  void onTurnStart(GameState gs) {}
 }
 
 /// Joker "doble paso": the affected side's pieces gain a **2-square** option in
@@ -134,5 +143,82 @@ class AreaCaptureModifier extends RuleModifier {
       [i, j + 1],
       [i, j - 1],
     ];
+  }
+}
+
+/// Llama boss (life 2) "Rebrote": each turn a fresh [piece] of the mover's side
+/// sprouts on the board. Placement is the first empty tile scanning from the
+/// mover's home rank (j=0) outward; if the board is full, nothing spawns.
+class SpawnModifier extends RuleModifier {
+  const SpawnModifier({this.piece = chrt.pawn, this.side = possession.none});
+
+  final chrt piece;
+
+  @override
+  final possession side;
+
+  @override
+  void onTurnStart(GameState gs) {
+    for (final row in gs.board) {
+      for (final t in row) {
+        if (t.char == chrt.empty) {
+          t.char = piece;
+          t.owner = possession.mine;
+          return;
+        }
+      }
+    }
+  }
+}
+
+/// Cóndor boss (life 2) "Viento": every piece is pushed one step by `[di, dj]`.
+/// A piece blown off the board is removed to its own owner's graveyard. Because
+/// the push is a rigid translation, distinct pieces never collide; processing
+/// the frontier (pieces nearest the push edge) first keeps each destination
+/// free before the next piece arrives.
+class WindModifier extends RuleModifier {
+  const WindModifier(
+      {required this.di, required this.dj, this.side = possession.none});
+
+  final int di;
+  final int dj;
+
+  @override
+  final possession side;
+
+  @override
+  void onTurnStart(GameState gs) {
+    final height = gs.board.length;
+    final width = gs.board.isEmpty ? 0 : gs.board[0].length;
+
+    final pieces = <Tile>[
+      for (final row in gs.board)
+        for (final t in row)
+          if (t.char != chrt.empty) t
+    ];
+    // Frontier first: highest projection onto the push vector moves first.
+    pieces.sort((a, b) =>
+        (b.i! * di + b.j! * dj).compareTo(a.i! * di + a.j! * dj));
+
+    for (final t in pieces) {
+      final ni = t.i! + di;
+      final nj = t.j! + dj;
+      final char = t.char;
+      final owner = t.owner;
+      t.char = chrt.empty;
+      t.owner = possession.none;
+      if (nj < 0 || nj >= height || ni < 0 || ni >= width) {
+        // Blown off the board -> removed to its owner's graveyard.
+        if (owner == possession.mine) {
+          gs.myGraveyard.add(Tile(char, possession.mine, null, null));
+        } else {
+          gs.enemyGraveyard.add(Tile(char, possession.enemy, null, null));
+        }
+      } else {
+        final dest = gs.board[nj][ni];
+        dest.char = char;
+        dest.owner = owner;
+      }
+    }
   }
 }

--- a/lib/app/utils/gameObjects/gameState.dart
+++ b/lib/app/utils/gameObjects/gameState.dart
@@ -41,6 +41,17 @@ class GameState {
     return this;
   }
 
+  // Runs every active modifier's per-turn effect (spawn, wither, wind...). Call
+  // once when a side's turn begins, with that side as `mine`. Pure w.r.t. the
+  // engine; the match loop decides when to invoke it. No-op with no modifiers.
+  void applyTurnStart() {
+    for (final m in modifiers) {
+      if (m.appliesTo(possession.mine)) {
+        m.onTurnStart(this);
+      }
+    }
+  }
+
   transformPawn(Move move) {
     if (move.finalTile.char == chrt.pawn &&
         move.finalTile.j == config.promotionRow) {

--- a/test/engine/rule_modifier_test.dart
+++ b/test/engine/rule_modifier_test.dart
@@ -154,4 +154,70 @@ void main() {
       expect(gs.myGraveyard, isEmpty);
     });
   });
+
+  group('applyTurnStart with no modifiers', () {
+    test('does nothing', () {
+      final b = _emptyBoard();
+      b[0][0] = Tile(chrt.rock, possession.mine, 0, 0);
+      final gs = _boardStateWith(b, const []);
+      gs.applyTurnStart();
+      expect(b[0][0].char, chrt.rock);
+      final occupied =
+          b.expand((r) => r).where((t) => t.char != chrt.empty).length;
+      expect(occupied, 1);
+    });
+  });
+
+  group('SpawnModifier (Rebrote)', () {
+    test('sprouts a piece on the first empty tile each turn', () {
+      final b = _emptyBoard();
+      b[0][0] = Tile(chrt.rock, possession.mine, 0, 0); // occupies the very first tile
+      final gs = _boardStateWith(b, const [SpawnModifier(piece: chrt.pawn)]);
+      gs.applyTurnStart();
+      // first empty scanning j=0,i=0.. is (i=1, j=0) == board[0][1]
+      expect(b[0][1].char, chrt.pawn);
+      expect(b[0][1].owner, possession.mine);
+    });
+
+    test('a full board spawns nothing', () {
+      final b = List.generate(
+          4,
+          (j) => List.generate(
+              3, (i) => Tile(chrt.pawn, possession.mine, i, j)));
+      final gs = _boardStateWith(b, const [SpawnModifier()]);
+      gs.applyTurnStart(); // must not throw or overwrite
+      expect(b.expand((r) => r).every((t) => t.char == chrt.pawn), isTrue);
+    });
+  });
+
+  group('WindModifier (Viento)', () {
+    test('pushes pieces one step; those blown off go to the graveyard', () {
+      final b = _emptyBoard();
+      b[1][1] = Tile(chrt.pawn, possession.mine, 1, 1); // -> (1,2)
+      b[3][0] = Tile(chrt.rock, possession.enemy, 0, 3); // top row -> off board
+      final gs = _boardStateWith(b, const [WindModifier(di: 0, dj: 1)]);
+      gs.applyTurnStart();
+      // pushed +j
+      expect(b[2][1].char, chrt.pawn);
+      expect(b[2][1].owner, possession.mine);
+      expect(b[1][1].char, chrt.empty); // origin cleared
+      // rock blown off the far edge -> enemy graveyard, origin cleared
+      expect(b[3][0].char, chrt.empty);
+      expect(gs.enemyGraveyard.length, 1);
+      expect(gs.enemyGraveyard.first.char, chrt.rock);
+      expect(gs.enemyGraveyard.first.owner, possession.enemy);
+    });
+
+    test('adjacent pieces shift without colliding', () {
+      final b = _emptyBoard();
+      b[1][1] = Tile(chrt.pawn, possession.mine, 1, 1); // -> (1,2)
+      b[2][1] = Tile(chrt.bishop, possession.mine, 1, 2); // -> (1,3), moves first
+      final gs = _boardStateWith(b, const [WindModifier(di: 0, dj: 1)]);
+      gs.applyTurnStart();
+      expect(b[3][1].char, chrt.bishop);
+      expect(b[2][1].char, chrt.pawn);
+      expect(b[1][1].char, chrt.empty);
+      expect(gs.myGraveyard, isEmpty); // nobody blown off
+    });
+  });
 }


### PR DESCRIPTION
Third engine hook of the **campaign / rule-modifier** system (after movement + capture in #18).

## What
`RuleModifier` gains a **per-turn hook**, `onTurnStart(gs)` — a chance to mutate the board outside a normal move (spawn, wither, wind), in the mover's frame. `GameState.applyTurnStart()` runs each applicable modifier's tick.

- **`SpawnModifier`** (Llama "Rebrote"): each turn sprouts a piece on the first empty tile.
- **`WindModifier`** (Cóndor "Viento"): rigid one-step push of every piece by `[di,dj]`; pieces blown off the board go to their owner's graveyard. Frontier-first ordering means a rigid translation never collides.

## Scope / safety
Pure engine only. `applyTurnStart()` is **not yet wired** into `MatchController` (like the earlier modifiers, it has no live caller until campaign integration) — so **zero effect on existing gameplay**. Empty modifier list == vanilla.

Same **known follow-up** as #18: tick `side` is frame-relative; stable player-vs-boss targeting comes when we wire modifiers into real matches.

Deferred: **Wither/Marchitar** (needs per-piece idle tracking) → its own PR.

## Verification
- `flutter analyze` — no new issues.
- `flutter test test/engine/` — **45/45 pass** (5 new + all pre-existing).

## Next PRs (sketch)
wither (idle tracking) → win/lives (checkmate, N lives) → setup (felled tiles, 5×4) → **stable side identity** → campaign/joker meta + UI wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)