### PR TITLE
feat(engine): stable side identity, wither, checkmate, felled tiles + 5x4 (campaign batch)

### DIFF
--- a/lib/app/engine/board_config.dart
+++ b/lib/app/engine/board_config.dart
@@ -24,6 +24,9 @@ class BoardConfig {
   /// The current game: a 3×4 board, pawn promotes to a knight.
   static const BoardConfig classic = BoardConfig(width: 3, height: 4);
 
+  /// The final-boss stage: a wider 5×4 board (pawn still promotes to a knight).
+  static const BoardConfig bossFinal = BoardConfig(width: 5, height: 4);
+
   /// Row a `mine` pawn promotes on (the far rank).
   int get promotionRow => height - 1;
 }

--- a/lib/app/engine/board_factory.dart
+++ b/lib/app/engine/board_factory.dart
@@ -29,3 +29,20 @@ List<List<Tile>> createNewBoard() {
     ],
   ];
 }
+
+/// Builds the 5×4 final-boss board ([BoardConfig.bossFinal]): a wider back rank
+/// (rock, bishop, king, bishop, rock) and a full pawn row each side — more
+/// pieces than the classic board. Point-symmetric, so the per-turn 180°
+/// rotation stays fair.
+List<List<Tile>> createBossFinalBoard() {
+  const back = [chrt.rock, chrt.bishop, chrt.king, chrt.bishop, chrt.rock];
+  final board = List.generate(4,
+      (j) => List.generate(5, (i) => Tile(chrt.empty, possession.none, i, j)));
+  for (var i = 0; i < 5; i++) {
+    board[0][i] = Tile(back[i], possession.mine, i, 0);
+    board[1][i] = Tile(chrt.pawn, possession.mine, i, 1);
+    board[2][i] = Tile(chrt.pawn, possession.enemy, i, 2);
+    board[3][i] = Tile(back[i], possession.enemy, i, 3);
+  }
+  return board;
+}

--- a/lib/app/engine/modifier_catalog.dart
+++ b/lib/app/engine/modifier_catalog.dart
@@ -1,0 +1,155 @@
+import '../data/enums.dart';
+import 'rule_modifier.dart';
+
+/// How a modifier is meant to be used in the campaign.
+enum ModifierUse { bossPower, joker }
+
+/// Human-readable metadata for a [RuleModifier] — so every power/joker lives in
+/// ONE place. A future debug screen, the joker-pick UI and the boss config can
+/// all read from here instead of hardcoding names/descriptions. Pure data plus a
+/// [sample] factory that builds a representative instance.
+class ModifierInfo {
+  ModifierInfo({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.uses,
+    required this.sample,
+    this.source,
+  });
+
+  /// Stable machine id (kebab-case).
+  final String id;
+
+  /// Short display name.
+  final String name;
+
+  /// What it does, in plain language.
+  final String description;
+
+  /// Whether it's used as a boss power, a joker, or both.
+  final Set<ModifierUse> uses;
+
+  /// For boss powers: which guardian/life it belongs to (e.g. 'Cóndor · vida 1').
+  /// Null for pure jokers.
+  final String? source;
+
+  /// Builds a representative instance (default tuning) of the modifier.
+  final RuleModifier Function() sample;
+
+  bool get isBossPower => uses.contains(ModifierUse.bossPower);
+  bool get isJoker => uses.contains(ModifierUse.joker);
+}
+
+/// Every rule modifier in the game and what it does — the single source of truth.
+///
+/// Note: "jaque mate real" and the boss's N-lives are NOT modifiers; they are
+/// engine primitives (`isCheckmate`) / match-loop state wired at campaign
+/// integration, so they don't appear here.
+final List<ModifierInfo> modifierCatalog = [
+  ModifierInfo(
+    id: 'double-step',
+    name: 'Doble paso',
+    description:
+        'Las fichas ganan la opción de avanzar 2 casillas, además de su paso '
+        'normal de 1. (El poder del Sol · vida 2 es una variante que reemplaza '
+        'el paso de 1 por 2.)',
+    uses: {ModifierUse.joker},
+    sample: () => const DoubleStepModifier(side: ModifierSide.protagonist),
+  ),
+  ModifierInfo(
+    id: 'transform-all-osos',
+    name: 'Todas se vuelven osos',
+    description:
+        'Todas las fichas del bando afectado se mueven como el oso (caballo), '
+        'sin importar qué pieza sean. El rey no cambia.',
+    uses: {ModifierUse.bossPower},
+    source: 'Oso · vida 2',
+    sample: () => const TransformAllPiecesModifier(
+        target: chrt.knight, side: ModifierSide.antagonist),
+  ),
+  ModifierInfo(
+    id: 'return-captured',
+    name: 'Invertir posesión de captura',
+    description:
+        'Las fichas capturadas no pasan a quien las captura: regresan a su '
+        'dueño original (sin "drops" del enemigo).',
+    uses: {ModifierUse.joker},
+    sample: () => const ReturnCapturedModifier(),
+  ),
+  ModifierInfo(
+    id: 'area-capture',
+    name: 'Embestida',
+    description:
+        'Al capturar, también elimina las fichas enemigas ortogonalmente '
+        'adyacentes a donde cae la ficha.',
+    uses: {ModifierUse.bossPower, ModifierUse.joker},
+    source: 'Oso · alternativa',
+    sample: () => const AreaCaptureModifier(side: ModifierSide.antagonist),
+  ),
+  ModifierInfo(
+    id: 'spawn',
+    name: 'Rebrote',
+    description:
+        'Cada turno brota una ficha nueva del bando afectado en la primera '
+        'casilla vacía. Un tablero lleno no genera nada.',
+    uses: {ModifierUse.bossPower},
+    source: 'Llama · vida 2',
+    sample: () =>
+        const SpawnModifier(piece: chrt.pawn, side: ModifierSide.antagonist),
+  ),
+  ModifierInfo(
+    id: 'wind',
+    name: 'Viento',
+    description:
+        'Empuja todas las fichas un paso en una dirección. Las que salen del '
+        'tablero se van al cementerio de su dueño.',
+    uses: {ModifierUse.bossPower},
+    source: 'Cóndor · vida 2',
+    sample: () =>
+        const WindModifier(di: 0, dj: 1, side: ModifierSide.antagonist),
+  ),
+  ModifierInfo(
+    id: 'wither',
+    name: 'Marchitar',
+    description:
+        'Una ficha que su dueño deja sin mover durante N turnos se marchita y '
+        'muere (va al cementerio). El rey nunca se marchita.',
+    uses: {ModifierUse.bossPower},
+    source: 'Cóndor · vida 1',
+    sample: () =>
+        const WitherModifier(turns: 3, side: ModifierSide.antagonist),
+  ),
+  ModifierInfo(
+    id: 'felled-tiles',
+    name: 'Tala el tablero',
+    description:
+        'Marca casillas "taladas" que el bando afectado (por defecto el '
+        'protagonista) no puede pisar; el leñador sí puede.',
+    uses: {ModifierUse.bossPower},
+    source: 'Leñador (Oso) · vida 1',
+    sample: () => FelledTilesModifier(const [
+      [1, 2]
+    ]),
+  ),
+];
+
+/// Only the boss powers, in catalog order.
+List<ModifierInfo> get bossPowerCatalog =>
+    modifierCatalog.where((m) => m.isBossPower).toList();
+
+/// Only the jokers, in catalog order.
+List<ModifierInfo> get jokerCatalog =>
+    modifierCatalog.where((m) => m.isJoker).toList();
+
+/// A plain-text dump of the whole catalog — handy for a debug print/screen until
+/// there's real UI.
+String catalogAsText() {
+  final b = StringBuffer();
+  for (final m in modifierCatalog) {
+    final tags = m.uses.map((u) => u.name).join(', ');
+    b.writeln('• ${m.name}  [$tags]${m.source == null ? '' : ' — ${m.source}'}');
+    b.writeln('    ${m.description}');
+  }
+  return b.toString();
+}

--- a/lib/app/engine/rule_modifier.dart
+++ b/lib/app/engine/rule_modifier.dart
@@ -4,79 +4,82 @@ import '../utils/gameObjects/move.dart';
 import '../utils/gameObjects/tile.dart';
 import 'rules.dart';
 
+/// Whom a [RuleModifier] targets. Unlike [possession] (which is frame-relative —
+/// the mover is always `mine` because the board rotates every turn), these are
+/// STABLE identities, resolved via [GameState.mineIsProtagonist], so a boss-only
+/// power keeps hitting the boss across turns.
+enum ModifierSide { both, protagonist, antagonist }
+
 /// A rule change carried by a [GameState] and applied at defined engine hook
 /// points. Boss powers (campaign) and player jokers are both [RuleModifier]s;
-/// [side] marks who it affects.
+/// [side] marks who it affects (stably — see [ModifierSide]).
 ///
 /// Every hook defaults to a no-op, so an **empty modifier list == vanilla
-/// rules** — the engine behaves exactly as before unless a match opts in. This
-/// is the single extension seam the campaign/joker systems build on. Modifiers
-/// must be immutable: a [GameState] is cloned constantly by the AI look-ahead
-/// and only the reference to the modifier list is copied.
+/// rules**. Modifiers must be immutable: a [GameState] is cloned constantly by
+/// the AI look-ahead and only the reference to the modifier list is copied.
 ///
-/// PR 1 shipped the movement hook ([transformOffsets]); PR 2 adds the capture
-/// hooks ([returnsCapturedToOwner], [extraCaptures]). Later hooks (per-turn
-/// ticks, win condition) will be added the same way — each defaulting to a
-/// no-op so existing modifiers keep compiling.
-///
-/// SIDE CAVEAT: at capture time the mover is always [possession.mine] (the board
-/// rotates each turn), so for the capture hooks [side] is frame-relative ("the
-/// side to move"), not a stable player/boss identity. Durable player-vs-boss
-/// targeting is a known follow-up (the [GameState] must carry which frame is the
-/// protagonist's).
+/// Hooks: [transformOffsets] (movement), [allowsMove] (move legality),
+/// [returnsCapturedToOwner] + [extraCaptures] (capture resolution),
+/// [onTurnStart] (per-turn effects). The engine gates each by [appliesTo].
 abstract class RuleModifier {
   const RuleModifier();
 
-  /// Which side the modifier affects. [possession.none] means both sides.
-  possession get side => possession.none;
+  /// Stable target side. Default: both.
+  ModifierSide get side => ModifierSide.both;
 
-  bool appliesTo(possession owner) =>
-      side == possession.none || side == owner;
+  /// Whether this modifier affects a piece/move owned by [owner] in [gs]'s
+  /// current frame — mapping the stable [side] onto the rotating `mine`/`enemy`.
+  bool appliesTo(possession owner, GameState gs) {
+    switch (side) {
+      case ModifierSide.both:
+        return true;
+      case ModifierSide.protagonist:
+        return (owner == possession.mine) == gs.mineIsProtagonist;
+      case ModifierSide.antagonist:
+        return (owner == possession.mine) != gs.mineIsProtagonist;
+    }
+  }
 
-  /// Movement hook. Given a piece's [base] relative offsets (from
-  /// [pieceOffsets]), return the offsets it may actually use. Default: the
-  /// offsets are returned unchanged. Implementations must return a **new** list
-  /// and never mutate [base] (some base tables are `const`).
+  /// Movement hook. Transform a piece's [base] relative offsets (from
+  /// [pieceOffsets]). Called by [effectiveOffsets] only when [appliesTo] the
+  /// piece's owner. Must return a **new** list, never mutate [base].
   List<List<int>> transformOffsets(
           chrt piece, possession owner, List<List<int>> base) =>
       base;
 
+  /// Legality hook. Return false to veto an otherwise-legal [move] (e.g. a tile
+  /// the protagonist may not enter). Default: allowed.
+  bool allowsMove(Move move, GameState gs) => true;
+
   /// Capture hook — disposition. If true, a piece captured by the current mover
-  /// is **not** claimed by the captor (the vanilla, Shogi-style drop); it
-  /// returns to its original owner instead. The first applicable modifier wins.
+  /// is **not** claimed by the captor (the vanilla Shogi-style drop); it returns
+  /// to its original owner instead. The first applicable modifier wins.
   bool returnsCapturedToOwner() => false;
 
   /// Capture hook — side effects. Extra board tiles (`[i, j]` pairs) cleared as
-  /// a consequence of a capturing [move] (e.g. the Oso's "Embestida" area hit).
-  /// Off-board or non-enemy tiles in the result are ignored by the engine.
-  /// Default: none.
+  /// a consequence of a capturing [move] (e.g. the Oso's "Embestida"). Off-board
+  /// or non-enemy tiles in the result are ignored by the engine. Default: none.
   List<List<int>> extraCaptures(Move move, GameState gs) => const [];
 
   /// Per-turn hook. Runs once at the start of the side-to-move's turn (the mover
-  /// is [possession.mine] in the current frame), letting a modifier mutate the
-  /// board outside of a normal move — spawn reinforcements, wither idle pieces,
-  /// blow a wind across the board. Default: no-op.
-  ///
-  /// Frame-relative like the capture hooks (see the SIDE CAVEAT above).
+  /// is `mine`), letting a modifier mutate the board outside a normal move —
+  /// spawn reinforcements, wither idle pieces, blow a wind. Default: no-op.
   void onTurnStart(GameState gs) {}
 }
 
 /// Joker "doble paso": the affected side's pieces gain a **2-square** option in
 /// each direction they can already move, on top of their normal 1-square moves.
-///
-/// The board has no path/blocking logic (every base move is a single exact
-/// step), so a 2-step move simply reaches a farther exact square — consistent
-/// with how the engine already models movement.
+/// The board has no path/blocking logic (every base move is one exact step), so
+/// a 2-step move simply reaches a farther exact square.
 class DoubleStepModifier extends RuleModifier {
-  const DoubleStepModifier({this.side = possession.none});
+  const DoubleStepModifier({this.side = ModifierSide.both});
 
   @override
-  final possession side;
+  final ModifierSide side;
 
   @override
   List<List<int>> transformOffsets(
       chrt piece, possession owner, List<List<int>> base) {
-    if (!appliesTo(owner)) return base;
     return [
       ...base,
       for (final o in base) [o[0] * 2, o[1] * 2],
@@ -86,40 +89,35 @@ class DoubleStepModifier extends RuleModifier {
 
 /// Boss power (Oso, life 2) "todas se vuelven osos": every one of the affected
 /// side's pieces moves like [target] (default the knight/oso), regardless of
-/// what it actually is.
-///
-/// The **king is left untouched** — its move is gated specially by the engine
-/// (king-safety look-ahead) and it is the win target, so transforming it would
-/// change unrelated rules. Empty tiles are likewise ignored (they never move).
+/// what it actually is. The **king is left untouched** (its move is gated
+/// specially and it is the win target); empty tiles are ignored.
 class TransformAllPiecesModifier extends RuleModifier {
   const TransformAllPiecesModifier(
-      {this.target = chrt.knight, this.side = possession.none});
+      {this.target = chrt.knight, this.side = ModifierSide.both});
 
   final chrt target;
 
   @override
-  final possession side;
+  final ModifierSide side;
 
   @override
   List<List<int>> transformOffsets(
       chrt piece, possession owner, List<List<int>> base) {
-    if (!appliesTo(owner) || piece == chrt.king || piece == chrt.empty) {
-      return base;
-    }
-    // Resolve the target's offsets for THIS owner so direction-dependent
-    // targets (like the knight) still mirror correctly.
+    if (piece == chrt.king || piece == chrt.empty) return base;
+    // Resolve the target's offsets for THIS owner so direction-dependent targets
+    // (like the knight) still mirror correctly.
     return pieceOffsets(target, owner);
   }
 }
 
 /// Rule "invertir posesión de captura": captured pieces are never claimed by the
-/// captor — they return to their original owner (no Shogi-style drops from your
-/// own graveyard of the pieces you took).
+/// captor — they return to their original owner (no drops from the pieces you
+/// took).
 class ReturnCapturedModifier extends RuleModifier {
-  const ReturnCapturedModifier({this.side = possession.none});
+  const ReturnCapturedModifier({this.side = ModifierSide.both});
 
   @override
-  final possession side;
+  final ModifierSide side;
 
   @override
   bool returnsCapturedToOwner() => true;
@@ -128,10 +126,10 @@ class ReturnCapturedModifier extends RuleModifier {
 /// Oso "Embestida" (also a candidate joker): a capturing move also clears the
 /// orthogonally-adjacent enemy pieces around the square the mover lands on.
 class AreaCaptureModifier extends RuleModifier {
-  const AreaCaptureModifier({this.side = possession.none});
+  const AreaCaptureModifier({this.side = ModifierSide.both});
 
   @override
-  final possession side;
+  final ModifierSide side;
 
   @override
   List<List<int>> extraCaptures(Move move, GameState gs) {
@@ -147,15 +145,15 @@ class AreaCaptureModifier extends RuleModifier {
 }
 
 /// Llama boss (life 2) "Rebrote": each turn a fresh [piece] of the mover's side
-/// sprouts on the board. Placement is the first empty tile scanning from the
-/// mover's home rank (j=0) outward; if the board is full, nothing spawns.
+/// sprouts on the first empty tile (scanning from the home rank outward); a full
+/// board spawns nothing.
 class SpawnModifier extends RuleModifier {
-  const SpawnModifier({this.piece = chrt.pawn, this.side = possession.none});
+  const SpawnModifier({this.piece = chrt.pawn, this.side = ModifierSide.both});
 
   final chrt piece;
 
   @override
-  final possession side;
+  final ModifierSide side;
 
   @override
   void onTurnStart(GameState gs) {
@@ -174,17 +172,17 @@ class SpawnModifier extends RuleModifier {
 /// Cóndor boss (life 2) "Viento": every piece is pushed one step by `[di, dj]`.
 /// A piece blown off the board is removed to its own owner's graveyard. Because
 /// the push is a rigid translation, distinct pieces never collide; processing
-/// the frontier (pieces nearest the push edge) first keeps each destination
-/// free before the next piece arrives.
+/// the frontier (pieces nearest the push edge) first keeps each destination free
+/// before the next piece arrives.
 class WindModifier extends RuleModifier {
   const WindModifier(
-      {required this.di, required this.dj, this.side = possession.none});
+      {required this.di, required this.dj, this.side = ModifierSide.both});
 
   final int di;
   final int dj;
 
   @override
-  final possession side;
+  final ModifierSide side;
 
   @override
   void onTurnStart(GameState gs) {
@@ -196,7 +194,6 @@ class WindModifier extends RuleModifier {
         for (final t in row)
           if (t.char != chrt.empty) t
     ];
-    // Frontier first: highest projection onto the push vector moves first.
     pieces.sort((a, b) =>
         (b.i! * di + b.j! * dj).compareTo(a.i! * di + a.j! * dj));
 
@@ -208,7 +205,6 @@ class WindModifier extends RuleModifier {
       t.char = chrt.empty;
       t.owner = possession.none;
       if (nj < 0 || nj >= height || ni < 0 || ni >= width) {
-        // Blown off the board -> removed to its owner's graveyard.
         if (owner == possession.mine) {
           gs.myGraveyard.add(Tile(char, possession.mine, null, null));
         } else {
@@ -220,5 +216,59 @@ class WindModifier extends RuleModifier {
         dest.owner = owner;
       }
     }
+  }
+}
+
+/// Cóndor boss (life 1) "Marchitar": a piece the mover leaves unmoved for
+/// [turns] of its own turns withers and dies (removed to its owner's graveyard).
+/// The king never withers. Ages the mover's pieces each turn; moving a piece
+/// resets its age (see [GameState.rewritePosition]).
+class WitherModifier extends RuleModifier {
+  const WitherModifier({this.turns = 3, this.side = ModifierSide.both});
+
+  final int turns;
+
+  @override
+  final ModifierSide side;
+
+  @override
+  void onTurnStart(GameState gs) {
+    for (final row in gs.board) {
+      for (final t in row) {
+        if (t.owner != possession.mine ||
+            t.char == chrt.empty ||
+            t.char == chrt.king) {
+          continue;
+        }
+        t.idleTurns++;
+        if (t.idleTurns >= turns) {
+          gs.myGraveyard.add(Tile(t.char, possession.mine, null, null));
+          t.char = chrt.empty;
+          t.owner = possession.none;
+          t.idleTurns = 0;
+        }
+      }
+    }
+  }
+}
+
+/// Leñador boss (life 1) "Tala el tablero": the [felled] tiles (`[i, j]` pairs)
+/// may not be entered by the side this modifier applies to (default the
+/// protagonist) — the leñador itself may still step on them.
+class FelledTilesModifier extends RuleModifier {
+  const FelledTilesModifier(this.felled, {this.side = ModifierSide.protagonist});
+
+  final List<List<int>> felled;
+
+  @override
+  final ModifierSide side;
+
+  @override
+  bool allowsMove(Move move, GameState gs) {
+    if (!appliesTo(move.initialTile.owner, gs)) return true;
+    for (final c in felled) {
+      if (c[0] == move.finalTile.i && c[1] == move.finalTile.j) return false;
+    }
+    return true;
   }
 }

--- a/lib/app/engine/rules.dart
+++ b/lib/app/engine/rules.dart
@@ -71,15 +71,39 @@ bool isProtecting(Move m, GameState gs, bool hard) {
 
 bool checkIfValidMove(Move m, GameState gs, [bool hard = false]) {
   //TODO: Enhace: check if is players turn, and check of move have initial and final tile
+  final bool base;
   if (isFromGraveyard(m.initialTile)) {
-    return m.finalTile.char == chrt.empty;
+    base = m.finalTile.char == chrt.empty;
+  } else if (m.initialTile.owner == m.finalTile.owner) {
+    base = false;
   } else {
-    if (m.initialTile.owner == m.finalTile.owner) {
-      return false;
-    } else {
-      return isValidMovmentPerPiece(m, gs, hard);
+    base = isValidMovmentPerPiece(m, gs, hard);
+  }
+  if (!base) return false;
+  // Modifiers may veto an otherwise-legal move (e.g. felled tiles).
+  for (final mod in gs.modifiers) {
+    if (!mod.allowsMove(m, gs)) return false;
+  }
+  return true;
+}
+
+/// Whether the side to move (`mine`) is checkmated: its king is attacked and no
+/// legal move escapes. The base game has no check — you win by capturing the
+/// king — so this powers only the "jaque mate real" campaign win condition.
+bool isCheckmate(GameState gs) {
+  if (!isInCheck(gs)) return false;
+  for (final piece in getMyPieces(gs)) {
+    for (final row in gs.board) {
+      for (final tile in row) {
+        final m = Move(piece, tile);
+        if (!checkIfValidMove(m, gs, true)) continue;
+        final next = GameState.clone(gs);
+        next.changeGameState(m);
+        if (!isInCheck(next)) return false; // an escape exists
+      }
     }
   }
+  return true;
 }
 
 /// Relative `[di, dj]` steps a piece may take, from the perspective of its
@@ -145,7 +169,9 @@ List<List<int>> pieceOffsets(chrt piece, possession owner) {
 List<List<int>> effectiveOffsets(chrt piece, possession owner, GameState gs) {
   var offsets = pieceOffsets(piece, owner);
   for (final m in gs.modifiers) {
-    offsets = m.transformOffsets(piece, owner, offsets);
+    if (m.appliesTo(owner, gs)) {
+      offsets = m.transformOffsets(piece, owner, offsets);
+    }
   }
   return offsets;
 }

--- a/lib/app/utils/gameObjects/gameState.dart
+++ b/lib/app/utils/gameObjects/gameState.dart
@@ -11,16 +11,21 @@ import 'move.dart';
 
 class GameState {
   GameState(this.board, this.myGraveyard, this.enemyGraveyard,
-      {this.config = BoardConfig.classic, this.modifiers = const []});
+      {this.config = BoardConfig.classic,
+      this.modifiers = const [],
+      this.mineIsProtagonist = true});
 
   GameState.named(
       {board,
       myGraveyard,
       enemyGraveyard,
       BoardConfig config = BoardConfig.classic,
-      List<RuleModifier> modifiers = const []})
+      List<RuleModifier> modifiers = const [],
+      bool mineIsProtagonist = true})
       : this(board, myGraveyard, enemyGraveyard,
-            config: config, modifiers: modifiers);
+            config: config,
+            modifiers: modifiers,
+            mineIsProtagonist: mineIsProtagonist);
 
   List<List<Tile>> board;
   List<Tile> myGraveyard;
@@ -30,6 +35,12 @@ class GameState {
   /// Active rule changes (boss powers / jokers). Empty == vanilla rules.
   /// Modifiers are immutable, so [clone] copies the list reference.
   final List<RuleModifier> modifiers;
+
+  /// Whether the current `mine` frame belongs to the protagonist (the human /
+  /// campaign hero). The board rotates each turn, so `mine`/`enemy` flip owners;
+  /// this stable flag lets a [RuleModifier] target the protagonist or antagonist
+  /// durably (see [RuleModifier.appliesTo]). Flipped by [rotate].
+  bool mineIsProtagonist;
 
   GameState changeGameState(Move move) {
     // `move.finalTile` aliases the board tile, which `rewritePosition` overwrites
@@ -46,7 +57,7 @@ class GameState {
   // engine; the match loop decides when to invoke it. No-op with no modifiers.
   void applyTurnStart() {
     for (final m in modifiers) {
-      if (m.appliesTo(possession.mine)) {
+      if (m.appliesTo(possession.mine, this)) {
         m.onTurnStart(this);
       }
     }
@@ -70,8 +81,8 @@ class GameState {
   // it to its original owner. At this point the captor is always `mine`, so the
   // captured piece's [owner] is `enemy`.
   void _sendToGrave(chrt char, possession owner) {
-    final returnToOwner = modifiers
-        .any((m) => m.appliesTo(possession.mine) && m.returnsCapturedToOwner());
+    final returnToOwner = modifiers.any(
+        (m) => m.appliesTo(possession.mine, this) && m.returnsCapturedToOwner());
     if (returnToOwner) {
       enemyGraveyard.add(Tile(char, owner, null, null));
     } else {
@@ -84,7 +95,7 @@ class GameState {
   // enemy-occupied, on-board tiles are affected.
   void applyExtraCaptures(Move move) {
     for (final m in modifiers) {
-      if (!m.appliesTo(possession.mine)) continue;
+      if (!m.appliesTo(possession.mine, this)) continue;
       for (final c in m.extraCaptures(move, this)) {
         final i = c[0];
         final j = c[1];
@@ -104,6 +115,7 @@ class GameState {
   rewritePosition(Move move) {
     board[move.finalTile.j!][move.finalTile.i!].char = move.initialTile.char;
     board[move.finalTile.j!][move.finalTile.i!].owner = move.initialTile.owner;
+    board[move.finalTile.j!][move.finalTile.i!].idleTurns = 0; // moving resets wither
     transformPawn(move);
     if (isFromGraveyard(move.initialTile)) {
       int idxRemove = myGraveyard.indexWhere((t) => t.char == move.initialTile.char);
@@ -128,7 +140,7 @@ class GameState {
     for (var r in board){
       List<Tile> row = [];
       for(var t in r) {
-        row.add(Tile(t.char, t.owner, t.i, t.j));
+        row.add(Tile(t.char, t.owner, t.i, t.j, idleTurns: t.idleTurns));
       }
       newBoard.add(row);
     }
@@ -142,6 +154,7 @@ class GameState {
       enemyGraveyard: [...gs.enemyGraveyard],
       config: gs.config,
       modifiers: gs.modifiers,
+      mineIsProtagonist: gs.mineIsProtagonist,
     );
   }
 
@@ -164,7 +177,8 @@ class GameState {
       List<Tile> revRow = [];
       int j = 0;
       for (var v in row.reversed) {
-        revRow.add(Tile(v.char, toggleOwner(v.owner), j, i));
+        revRow.add(Tile(v.char, toggleOwner(v.owner), j, i,
+            idleTurns: v.idleTurns));
         j++;
       }
       reversedBoard.add(revRow);
@@ -175,6 +189,7 @@ class GameState {
 
   rotate() {
     board = getReversedBoard();
+    mineIsProtagonist = !mineIsProtagonist; // `mine` now refers to the other side
     var aux = myGraveyard.map((e) {
       e.owner = possession.enemy;
       return e;

--- a/lib/app/utils/gameObjects/tile.dart
+++ b/lib/app/utils/gameObjects/tile.dart
@@ -1,7 +1,7 @@
 import '../../data/enums.dart';
 
 class Tile {
-  Tile(this.char, this.owner, this.i, this.j);
+  Tile(this.char, this.owner, this.i, this.j, {this.idleTurns = 0});
 
   Tile.fromTile(Tile otherTile) :
         char = otherTile.char,
@@ -26,6 +26,11 @@ class Tile {
   late int? j;
   bool isSelected = false;
   bool isOption = false;
+
+  /// Consecutive turns this piece's owner has left it unmoved. Used by the
+  /// "Marchitar" rule modifier; carried across board copies/rotations, reset to
+  /// 0 when the piece moves.
+  int idleTurns = 0;
 
   @override
   String toString() {

--- a/test/engine/board_config_test.dart
+++ b/test/engine/board_config_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:inti_the_inka_chess_game/app/data/enums.dart';
 import 'package:inti_the_inka_chess_game/app/engine/board_config.dart';
+import 'package:inti_the_inka_chess_game/app/engine/board_factory.dart';
 import 'package:inti_the_inka_chess_game/app/utils/gameObjects/gameState.dart';
 import 'package:inti_the_inka_chess_game/app/utils/gameObjects/move.dart';
 import 'package:inti_the_inka_chess_game/app/utils/gameObjects/tile.dart';
@@ -18,6 +19,30 @@ void main() {
     });
     test('promotionRow is the far rank (height - 1)', () {
       expect(const BoardConfig(width: 5, height: 6).promotionRow, 5);
+    });
+    test('bossFinal is a wider 5x4 board', () {
+      expect(BoardConfig.bossFinal.width, 5);
+      expect(BoardConfig.bossFinal.height, 4);
+      expect(BoardConfig.bossFinal.promotesTo, chrt.knight);
+    });
+  });
+
+  group('createBossFinalBoard', () {
+    final board = createBossFinalBoard();
+    test('is 4 rows x 5 cols', () {
+      expect(board.length, 4);
+      expect(board.every((r) => r.length == 5), isTrue);
+    });
+    test('back ranks are rock, bishop, king, bishop, rock (king centered)', () {
+      expect(board[0].map((t) => t.char).toList(),
+          [chrt.rock, chrt.bishop, chrt.king, chrt.bishop, chrt.rock]);
+      expect(board[0].every((t) => t.owner == possession.mine), isTrue);
+      expect(board[3][2].char, chrt.king);
+      expect(board[3].every((t) => t.owner == possession.enemy), isTrue);
+    });
+    test('each side has a full pawn row', () {
+      expect(board[1].every((t) => t.char == chrt.pawn), isTrue);
+      expect(board[2].every((t) => t.char == chrt.pawn), isTrue);
     });
   });
 

--- a/test/engine/modifier_catalog_test.dart
+++ b/test/engine/modifier_catalog_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:inti_the_inka_chess_game/app/engine/modifier_catalog.dart';
+import 'package:inti_the_inka_chess_game/app/engine/rule_modifier.dart';
+
+// Keeps the modifier catalog honest: unique ids, every entry builds a real
+// RuleModifier, and every entry is usable as at least a boss power or a joker.
+
+void main() {
+  group('modifierCatalog', () {
+    test('is not empty', () {
+      expect(modifierCatalog, isNotEmpty);
+    });
+
+    test('ids are unique', () {
+      final ids = modifierCatalog.map((m) => m.id).toList();
+      expect(ids.toSet().length, ids.length);
+    });
+
+    test('every entry builds a RuleModifier and has a use + description', () {
+      for (final m in modifierCatalog) {
+        expect(m.sample(), isA<RuleModifier>(), reason: m.id);
+        expect(m.uses, isNotEmpty, reason: m.id);
+        expect(m.name.trim(), isNotEmpty, reason: m.id);
+        expect(m.description.trim(), isNotEmpty, reason: m.id);
+      }
+    });
+
+    test('boss powers name their source; the split covers everything', () {
+      for (final m in bossPowerCatalog) {
+        expect(m.source, isNotNull, reason: '${m.id} is a boss power');
+      }
+      expect(bossPowerCatalog.length + jokerCatalog.length,
+          greaterThanOrEqualTo(modifierCatalog.length));
+    });
+
+    test('catalogAsText lists every modifier', () {
+      final text = catalogAsText();
+      for (final m in modifierCatalog) {
+        expect(text, contains(m.name), reason: m.id);
+      }
+    });
+  });
+}

--- a/test/engine/rule_modifier_test.dart
+++ b/test/engine/rule_modifier_test.dart
@@ -59,20 +59,32 @@ void main() {
           _move(chrt.rock, possession.mine, 1, 1, 1, 3), gs, true), isFalse);
     });
 
-    test('side=mine leaves the enemy untouched', () {
-      final gs = _stateWith(const [DoubleStepModifier(side: possession.mine)]);
-      // mine gets the two-step...
+    test('side=protagonist leaves the enemy untouched', () {
+      final gs =
+          _stateWith(const [DoubleStepModifier(side: ModifierSide.protagonist)]);
+      // the protagonist (mine, in a default state) gets the two-step...
       expect(isValidMovmentPerPiece(
           _move(chrt.rock, possession.mine, 1, 1, 1, 3), gs, true), isTrue);
-      // ...the enemy does not.
+      // ...the antagonist (enemy) does not.
       expect(isValidMovmentPerPiece(
           _move(chrt.rock, possession.enemy, 1, 3, 1, 1), gs, true), isFalse);
+    });
+
+    test('stable targeting follows the protagonist across a rotation', () {
+      final gs =
+          _stateWith(const [DoubleStepModifier(side: ModifierSide.protagonist)]);
+      gs.rotate(); // now `mine` is the antagonist, `enemy` is the protagonist
+      // the protagonist is now the ENEMY-owned pieces -> they get the two-step.
+      expect(isValidMovmentPerPiece(
+          _move(chrt.rock, possession.enemy, 1, 1, 1, 3), gs, true), isTrue);
+      expect(isValidMovmentPerPiece(
+          _move(chrt.rock, possession.mine, 1, 1, 1, 3), gs, true), isFalse);
     });
   });
 
   group('TransformAllPiecesModifier (all become knights/osos)', () {
     final gs = _stateWith(
-        const [TransformAllPiecesModifier(side: possession.mine)]);
+        const [TransformAllPiecesModifier(side: ModifierSide.protagonist)]);
 
     test('a bishop moves like a knight (straight forward, normally illegal)',
         () {
@@ -92,7 +104,7 @@ void main() {
           pieceOffsets(chrt.king, possession.mine));
     });
 
-    test('the enemy side is untouched (side=mine)', () {
+    test('the enemy side is untouched (side=protagonist)', () {
       expect(effectiveOffsets(chrt.bishop, possession.enemy, gs),
           pieceOffsets(chrt.bishop, possession.enemy));
     });
@@ -218,6 +230,67 @@ void main() {
       expect(b[2][1].char, chrt.pawn);
       expect(b[1][1].char, chrt.empty);
       expect(gs.myGraveyard, isEmpty); // nobody blown off
+    });
+  });
+
+  group('WitherModifier (Marchitar)', () {
+    test('a piece unmoved for `turns` turns withers to the graveyard', () {
+      final b = _emptyBoard();
+      b[1][1] = Tile(chrt.bishop, possession.mine, 1, 1);
+      final gs = _boardStateWith(b, const [WitherModifier(turns: 2)]);
+      gs.applyTurnStart(); // idle 1
+      expect(b[1][1].char, chrt.bishop);
+      gs.applyTurnStart(); // idle 2 -> withers
+      expect(b[1][1].char, chrt.empty);
+      expect(gs.myGraveyard.length, 1);
+      expect(gs.myGraveyard.first.char, chrt.bishop);
+    });
+
+    test('moving a piece resets its wither clock', () {
+      final b = _emptyBoard();
+      b[1][1] = Tile(chrt.rock, possession.mine, 1, 1);
+      final gs = _boardStateWith(b, const [WitherModifier(turns: 2)]);
+      gs.applyTurnStart(); // idle 1
+      gs.changeGameState(Move(b[1][1], b[2][1])); // move (1,1)->(1,2): resets
+      gs.applyTurnStart(); // idle 1 again (on the new tile)
+      expect(b[2][1].char, chrt.rock); // still alive
+      expect(gs.myGraveyard, isEmpty);
+    });
+
+    test('the king never withers', () {
+      final b = _emptyBoard();
+      b[1][1] = Tile(chrt.king, possession.mine, 1, 1);
+      final gs = _boardStateWith(b, const [WitherModifier(turns: 1)]);
+      gs.applyTurnStart();
+      gs.applyTurnStart();
+      expect(b[1][1].char, chrt.king);
+    });
+  });
+
+  group('FelledTilesModifier (Tala el tablero)', () {
+    test('the protagonist cannot enter a felled tile; the antagonist can', () {
+      // (1,2) is felled. A rock at (1,1) wants to step onto it.
+      final felled = [
+        [1, 2]
+      ];
+      final gs = _boardStateWith(
+          _emptyBoard(), [FelledTilesModifier(felled)]); // side: protagonist
+      // protagonist == mine in a default state -> blocked.
+      expect(checkIfValidMove(
+          _move(chrt.rock, possession.mine, 1, 1, 1, 2), gs, true), isFalse);
+      // the antagonist (enemy) may still enter it.
+      expect(checkIfValidMove(
+          _move(chrt.rock, possession.enemy, 1, 1, 1, 2), gs, true), isTrue);
+    });
+
+    test('a non-felled tile stays reachable', () {
+      final gs = _boardStateWith(_emptyBoard(), [
+        FelledTilesModifier(const [
+          [0, 0]
+        ])
+      ]);
+      expect(checkIfValidMove(
+          _move(chrt.rock, possession.mine, 1, 1, 1, 2), gs, true), isTrue);
     });
   });
 }

--- a/test/engine/rules_test.dart
+++ b/test/engine/rules_test.dart
@@ -205,4 +205,31 @@ void main() {
       expect(isInCheck(_stateWith(b)), isTrue);
     });
   });
+
+  group('isCheckmate', () {
+    test('the initial position is not checkmate', () {
+      expect(isCheckmate(_stateWith(createNewBoard())), isFalse);
+    });
+
+    // My king cornered at (0,0): rock A at (0,1) gives check; rock B at (1,1)
+    // covers both escape squares and recaptures on either rook, so no move
+    // escapes -> mate.
+    List<List<Tile>> _matePosition() {
+      final b = _emptyBoard();
+      b[0][0] = Tile(chrt.king, possession.mine, 0, 0);
+      b[1][0] = Tile(chrt.rock, possession.enemy, 0, 1); // rook A
+      b[1][1] = Tile(chrt.rock, possession.enemy, 1, 1); // rook B
+      return b;
+    }
+
+    test('a cornered, inescapable king is checkmate', () {
+      expect(isCheckmate(_stateWith(_matePosition())), isTrue);
+    });
+
+    test('with only the checking rook, the king escapes (not mate)', () {
+      final b = _matePosition();
+      b[1][1] = Tile(chrt.empty, possession.none, 1, 1); // remove rook B
+      expect(isCheckmate(_stateWith(b)), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
Big batch completing the **pure-engine** rule-modifier toolkit (after #18 movement/capture and #19 ticks). Bundles the 4 remaining engine pieces so they can be reviewed/tested together.

## 1. Stable side identity (the flagged follow-up)
The board rotates each turn, so `mine`/`enemy` flip owners — previously a modifier's `side` was frame-relative and couldn't durably target "the boss."
- `GameState.mineIsProtagonist` (flipped in `rotate()`, copied in `clone`).
- `RuleModifier.side` is now a stable **`ModifierSide {both, protagonist, antagonist}`**, resolved via `appliesTo(owner, gs)`. All existing modifiers migrated.
- Test: a protagonist-targeted modifier follows the protagonist across a rotation.

## 2. Marchitar (Cóndor life 1)
- `Tile.idleTurns` (carried across clone/rotation, reset to 0 on move).
- **`WitherModifier`**: a piece left unmoved for N of its owner's turns dies (to graveyard). The **king never withers**.

## 3. Jaque mate real (Sol life 3) — primitive
- **`isCheckmate(gs)`**: king attacked and no legal move escapes (pure).
- ⚠️ **Deferred:** turning this into an actual win condition, and boss **N-lives** (revive + power swap), need the match/campaign loop and must not be consumed during AI look-ahead. They land in the campaign-integration PR.

## 4. Setup (Leñador + final board)
- **`FelledTilesModifier`**: tiles the protagonist may not enter, but the boss can — via a new **`allowsMove`** legality hook on `RuleModifier` + `checkIfValidMove`.
- **`BoardConfig.bossFinal`** (5×4) + **`createBossFinalBoard()`** (wider back rank, more pieces, point-symmetric).

## Scope / safety
Pure engine only — **nothing wired into `MatchController`** yet, so zero effect on live gameplay. Empty modifier list == vanilla.

## Verification
- `flutter analyze` — **0 errors** (pre-existing info/warning lints only).
- `flutter test test/engine/` — **58/58 pass**.
- `flutter build web` — compiles.

## Next
Campaign integration: wire modifiers + `applyTurnStart` + checkmate/lives into a campaign match flow, then the Slay-the-Spire map, jokers UI, and the reveal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)