### PR TITLE
feat(sandbox): play a match with a rule modifier active (debug tool)

### DIFF
--- a/lib/app/data/sandbox_config.dart
+++ b/lib/app/data/sandbox_config.dart
@@ -1,0 +1,10 @@
+import '../engine/rule_modifier.dart';
+
+/// Passed as the match route argument to launch a **sandbox** game: a normal
+/// solo match (vs the AI, classic 3×4 board) but with a set of [RuleModifier]s
+/// active, so any power/joker can be tried by hand. Debug-only for now.
+class SandboxConfig {
+  const SandboxConfig(this.modifiers);
+
+  final List<RuleModifier> modifiers;
+}

--- a/lib/app/engine/modifier_catalog.dart
+++ b/lib/app/engine/modifier_catalog.dart
@@ -111,8 +111,9 @@ final List<ModifierInfo> modifierCatalog = [
     name: 'Viento',
     description:
         'Cada 5 turnos una ventisca empuja las fichas del rival un paso hacia '
-        'atrás; las que salen del tablero van al cementerio. El rey queda anclado '
-        'y frena a las fichas detrás de él.',
+        'atrás; las que salen del tablero van al cementerio. El sol también se '
+        'mueve, pero nunca cae: en la última fila se queda y frena a la ficha '
+        'que tiene detrás.',
     uses: {ModifierUse.bossPower},
     source: 'Cóndor · vida 2',
     defaultSide: ModifierSide.antagonist,

--- a/lib/app/engine/modifier_catalog.dart
+++ b/lib/app/engine/modifier_catalog.dart
@@ -7,14 +7,15 @@ enum ModifierUse { bossPower, joker }
 /// Human-readable metadata for a [RuleModifier] — so every power/joker lives in
 /// ONE place. A future debug screen, the joker-pick UI and the boss config can
 /// all read from here instead of hardcoding names/descriptions. Pure data plus a
-/// [sample] factory that builds a representative instance.
+/// [build] factory that constructs the modifier for a chosen [ModifierSide].
 class ModifierInfo {
   ModifierInfo({
     required this.id,
     required this.name,
     required this.description,
     required this.uses,
-    required this.sample,
+    required this.build,
+    required this.defaultSide,
     this.source,
   });
 
@@ -34,8 +35,12 @@ class ModifierInfo {
   /// Null for pure jokers.
   final String? source;
 
-  /// Builds a representative instance (default tuning) of the modifier.
-  final RuleModifier Function() sample;
+  /// The side it naturally targets (a joker → protagonist, a boss power →
+  /// antagonist or the player it debuffs).
+  final ModifierSide defaultSide;
+
+  /// Builds the modifier targeting [side].
+  final RuleModifier Function(ModifierSide side) build;
 
   bool get isBossPower => uses.contains(ModifierUse.bossPower);
   bool get isJoker => uses.contains(ModifierUse.joker);
@@ -52,85 +57,88 @@ final List<ModifierInfo> modifierCatalog = [
     name: 'Doble paso',
     description:
         'Las fichas ganan la opción de avanzar 2 casillas, además de su paso '
-        'normal de 1. (El poder del Sol · vida 2 es una variante que reemplaza '
-        'el paso de 1 por 2.)',
+        'normal de 1.',
     uses: {ModifierUse.joker},
-    sample: () => const DoubleStepModifier(side: ModifierSide.protagonist),
+    defaultSide: ModifierSide.protagonist,
+    build: (side) => DoubleStepModifier(side: side),
   ),
   ModifierInfo(
     id: 'transform-all-osos',
     name: 'Todas se vuelven osos',
     description:
-        'Todas las fichas del bando afectado se mueven como el oso (caballo), '
+        'Todas las fichas del bando afectado se mueven (y se ven) como el oso, '
         'sin importar qué pieza sean. El rey no cambia.',
     uses: {ModifierUse.bossPower},
     source: 'Oso · vida 2',
-    sample: () => const TransformAllPiecesModifier(
-        target: chrt.knight, side: ModifierSide.antagonist),
+    defaultSide: ModifierSide.antagonist,
+    build: (side) =>
+        TransformAllPiecesModifier(target: chrt.knight, side: side),
   ),
   ModifierInfo(
     id: 'return-captured',
     name: 'Invertir posesión de captura',
     description:
         'Las fichas capturadas no pasan a quien las captura: regresan a su '
-        'dueño original (sin "drops" del enemigo).',
+        'dueño original (sin "drops").',
     uses: {ModifierUse.joker},
-    sample: () => const ReturnCapturedModifier(),
+    defaultSide: ModifierSide.protagonist,
+    build: (side) => ReturnCapturedModifier(side: side),
   ),
   ModifierInfo(
     id: 'area-capture',
     name: 'Embestida',
     description:
-        'Al capturar, también elimina las fichas enemigas ortogonalmente '
-        'adyacentes a donde cae la ficha.',
+        'Al capturar, elimina también las fichas enemigas ortogonalmente '
+        'adyacentes (nunca reyes).',
     uses: {ModifierUse.bossPower, ModifierUse.joker},
     source: 'Oso · alternativa',
-    sample: () => const AreaCaptureModifier(side: ModifierSide.antagonist),
+    defaultSide: ModifierSide.protagonist,
+    build: (side) => AreaCaptureModifier(side: side),
   ),
   ModifierInfo(
     id: 'spawn',
     name: 'Rebrote',
     description:
-        'Cada turno brota una ficha nueva del bando afectado en la primera '
-        'casilla vacía. Un tablero lleno no genera nada.',
+        'Cada 2 turnos brota una ficha nueva del bando afectado en su fila '
+        'trasera (primera casilla vacía). Un tablero lleno no genera nada.',
     uses: {ModifierUse.bossPower},
     source: 'Llama · vida 2',
-    sample: () =>
-        const SpawnModifier(piece: chrt.pawn, side: ModifierSide.antagonist),
+    defaultSide: ModifierSide.antagonist,
+    build: (side) => SpawnModifier(piece: chrt.pawn, everyTurns: 2, side: side),
   ),
   ModifierInfo(
     id: 'wind',
     name: 'Viento',
     description:
-        'Empuja todas las fichas un paso en una dirección. Las que salen del '
-        'tablero se van al cementerio de su dueño.',
+        'Cada 5 turnos una ventisca empuja todas las fichas un paso; las que '
+        'salen del tablero van al cementerio. El rey queda anclado.',
     uses: {ModifierUse.bossPower},
     source: 'Cóndor · vida 2',
-    sample: () =>
-        const WindModifier(di: 0, dj: 1, side: ModifierSide.antagonist),
+    defaultSide: ModifierSide.antagonist,
+    build: (side) => WindModifier(di: 0, dj: 1, everyTurns: 5, side: side),
   ),
   ModifierInfo(
     id: 'wither',
     name: 'Marchitar',
     description:
-        'Una ficha que su dueño deja sin mover durante N turnos se marchita y '
-        'muere (va al cementerio). El rey nunca se marchita.',
+        'Una ficha del bando afectado que no se mueve durante 3 turnos se '
+        'marchita y muere. El rey nunca se marchita.',
     uses: {ModifierUse.bossPower},
     source: 'Cóndor · vida 1',
-    sample: () =>
-        const WitherModifier(turns: 3, side: ModifierSide.antagonist),
+    defaultSide: ModifierSide.protagonist,
+    build: (side) => WitherModifier(turns: 3, side: side),
   ),
   ModifierInfo(
     id: 'felled-tiles',
     name: 'Tala el tablero',
     description:
-        'Marca casillas "taladas" que el bando afectado (por defecto el '
-        'protagonista) no puede pisar; el leñador sí puede.',
+        'Cada turno se tala una casilla nueva vecina a otra ya talada (dura 2 '
+        'turnos y vuelve a normal). El bando afectado no puede pisar casillas '
+        'taladas.',
     uses: {ModifierUse.bossPower},
     source: 'Leñador (Oso) · vida 1',
-    sample: () => FelledTilesModifier(const [
-      [1, 2]
-    ]),
+    defaultSide: ModifierSide.protagonist,
+    build: (side) => FelledTilesModifier(side: side),
   ),
 ];
 

--- a/lib/app/engine/modifier_catalog.dart
+++ b/lib/app/engine/modifier_catalog.dart
@@ -110,12 +110,13 @@ final List<ModifierInfo> modifierCatalog = [
     id: 'wind',
     name: 'Viento',
     description:
-        'Cada 5 turnos una ventisca empuja todas las fichas un paso; las que '
-        'salen del tablero van al cementerio. El rey queda anclado.',
+        'Cada 5 turnos una ventisca empuja las fichas del rival un paso hacia '
+        'atrás; las que salen del tablero van al cementerio. El rey queda anclado '
+        'y frena a las fichas detrás de él.',
     uses: {ModifierUse.bossPower},
     source: 'Cóndor · vida 2',
     defaultSide: ModifierSide.antagonist,
-    build: (side) => WindModifier(di: 0, dj: 1, everyTurns: 5, side: side),
+    build: (side) => WindModifier(everyTurns: 5, side: side),
   ),
   ModifierInfo(
     id: 'wither',

--- a/lib/app/engine/rule_modifier.dart
+++ b/lib/app/engine/rule_modifier.dart
@@ -10,6 +10,21 @@ import 'rules.dart';
 /// power keeps hitting the boss across turns.
 enum ModifierSide { both, protagonist, antagonist }
 
+/// A single piece movement a per-turn modifier effect will perform (e.g. a
+/// Viento gust shoving a piece one row). Reported by [RuleModifier.planTurnStart]
+/// *before* the board is mutated, so the UI can slide the piece from
+/// `(fromI, fromJ)` to `(toI, toJ)` with the normal move animation and only then
+/// commit the change. A `toJ` past the last row means the piece is blown off the
+/// board (into the graveyard) — the slide just carries it off the edge.
+class TickMove {
+  const TickMove(this.fromI, this.fromJ, this.toI, this.toJ);
+
+  final int fromI;
+  final int fromJ;
+  final int toI;
+  final int toJ;
+}
+
 /// A rule change carried by a [GameState] and applied at defined engine hook
 /// points. Boss powers (campaign) and player jokers are both [RuleModifier]s;
 /// [side] marks who it affects (stably — see [ModifierSide]).
@@ -70,6 +85,13 @@ abstract class RuleModifier {
   /// is `mine`), letting a modifier mutate the board outside a normal move —
   /// spawn reinforcements, wither idle pieces, blow a wind. Default: no-op.
   void onTurnStart(GameState gs) {}
+
+  /// The piece movements [onTurnStart] will perform this tick, reported *before*
+  /// the mutation so the UI can animate them. Called on the un-mutated board and
+  /// must NOT change state (nor advance any cadence counter) — it only predicts.
+  /// Must match what [onTurnStart] then does. Default: none (effects that don't
+  /// slide pieces, like spawn/wither, animate elsewhere).
+  List<TickMove> planTurnStart(GameState gs) => const [];
 }
 
 /// Joker "doble paso": the affected side's pieces gain a **2-square** option in
@@ -239,15 +261,20 @@ class WindModifier extends RuleModifier {
   /// Turns until the next gust (for UI).
   int get turnsUntilNext => _untilNext.clamp(0, everyTurns);
 
-  @override
-  void onTurnStart(GameState gs) {
-    if (--_untilNext > 0) return;
-    _untilNext = everyTurns;
+  /// Whether the gust fires on this tick (i.e. the next [onTurnStart] will blow).
+  bool _gustsNow() => _untilNext == 1;
 
+  /// The moves the gust performs, computed purely on [gs] without mutating it —
+  /// the single source of truth for both the animation ([planTurnStart]) and the
+  /// commit ([onTurnStart]). Simulates the frontier-first cascade on a scratch
+  /// occupancy grid so blocked pieces and freed squares resolve identically.
+  List<TickMove> _gustMoves(GameState gs) {
     final height = gs.board.length;
-    if (height == 0) return;
+    if (height == 0) return const [];
     final width = gs.board[0].length;
-
+    final occupied = List.generate(height,
+        (j) => List.generate(width, (i) => gs.board[j][i].char != chrt.empty));
+    final moves = <TickMove>[];
     for (int j = height - 1; j >= 0; j--) {
       for (int i = 0; i < width; i++) {
         final t = gs.board[j][i];
@@ -255,22 +282,48 @@ class WindModifier extends RuleModifier {
         if (t.char == chrt.empty || t.char == chrt.king) continue; // king anchored
         final nj = j + 1;
         if (nj >= height) {
-          // blown off the back edge -> its own graveyard
-          gs.enemyGraveyard
-              .add(Tile(gs.graveChar(t.char, t.owner), possession.enemy, null, null));
-          t.char = chrt.empty;
-          t.owner = possession.none;
-          t.idleTurns = 0;
-        } else {
-          final dest = gs.board[nj][i];
-          if (dest.char != chrt.empty) continue; // blocked -> holds position
-          dest.char = t.char;
-          dest.owner = t.owner;
-          dest.idleTurns = t.idleTurns;
-          t.char = chrt.empty;
-          t.owner = possession.none;
-          t.idleTurns = 0;
+          moves.add(TickMove(i, j, i, nj)); // blown off the back edge
+          occupied[j][i] = false;
+        } else if (!occupied[nj][i]) {
+          moves.add(TickMove(i, j, i, nj));
+          occupied[nj][i] = true;
+          occupied[j][i] = false;
         }
+        // else blocked -> holds position, no move
+      }
+    }
+    return moves;
+  }
+
+  @override
+  List<TickMove> planTurnStart(GameState gs) =>
+      _gustsNow() ? _gustMoves(gs) : const [];
+
+  @override
+  void onTurnStart(GameState gs) {
+    if (--_untilNext > 0) return;
+    _untilNext = everyTurns;
+
+    final height = gs.board.length;
+    // Apply the same frontier-first moves the plan reported. Destinations are
+    // freed before their occupants arrive (frontier processed first), so a
+    // clear-source-then-set-dest pass commits each move without collisions.
+    for (final mv in _gustMoves(gs)) {
+      final t = gs.board[mv.fromJ][mv.fromI];
+      final char = t.char;
+      final owner = t.owner;
+      final idle = t.idleTurns;
+      t.char = chrt.empty;
+      t.owner = possession.none;
+      t.idleTurns = 0;
+      if (mv.toJ >= height) {
+        gs.enemyGraveyard
+            .add(Tile(gs.graveChar(char, owner), possession.enemy, null, null));
+      } else {
+        final dest = gs.board[mv.toJ][mv.toI];
+        dest.char = char;
+        dest.owner = owner;
+        dest.idleTurns = idle;
       }
     }
   }

--- a/lib/app/engine/rule_modifier.dart
+++ b/lib/app/engine/rule_modifier.dart
@@ -47,6 +47,11 @@ abstract class RuleModifier {
           chrt piece, possession owner, List<List<int>> base) =>
       base;
 
+  /// Display hook (rendering only). The character to SHOW for a piece — may
+  /// differ from its stored [chrt] so a piece transformed to move like the oso
+  /// also looks like one. Default: unchanged.
+  chrt displayChar(chrt piece, possession owner) => piece;
+
   /// Legality hook. Return false to veto an otherwise-legal [move] (e.g. a tile
   /// the protagonist may not enter). Default: allowed.
   bool allowsMove(Move move, GameState gs) => true;
@@ -108,6 +113,10 @@ class TransformAllPiecesModifier extends RuleModifier {
     // (like the knight) still mirror correctly.
     return pieceOffsets(target, owner);
   }
+
+  @override
+  chrt displayChar(chrt piece, possession owner) =>
+      (piece == chrt.king || piece == chrt.empty) ? piece : target;
 }
 
 /// Rule "invertir posesión de captura": captured pieces are never claimed by the
@@ -144,19 +153,34 @@ class AreaCaptureModifier extends RuleModifier {
   }
 }
 
-/// Llama boss (life 2) "Rebrote": each turn a fresh [piece] of the mover's side
-/// sprouts on the first empty tile (scanning from the home rank outward); a full
-/// board spawns nothing.
+/// Llama boss (life 2) "Rebrote": every [everyTurns] of the affected side's turns
+/// a fresh [piece] sprouts on the first empty tile scanning from that side's home
+/// rank (j=0) outward — i.e. on its own back line first. A full board spawns
+/// nothing.
+///
+/// Holds a small countdown; [onTurnStart] is only ever called by the real match
+/// loop (never the AI look-ahead), so this mutable state is safe.
 class SpawnModifier extends RuleModifier {
-  const SpawnModifier({this.piece = chrt.pawn, this.side = ModifierSide.both});
+  SpawnModifier(
+      {this.piece = chrt.pawn,
+      this.everyTurns = 2,
+      this.side = ModifierSide.both});
 
   final chrt piece;
+  final int everyTurns;
 
   @override
   final ModifierSide side;
 
+  int _untilNext = 1; // first spawn on the first eligible turn, then every N
+
+  /// Turns until the next spawn (for UI); 1 means it sprouts this turn.
+  int get turnsUntilNext => _untilNext.clamp(0, everyTurns);
+
   @override
   void onTurnStart(GameState gs) {
+    if (--_untilNext > 0) return;
+    _untilNext = everyTurns;
     for (final row in gs.board) {
       for (final t in row) {
         if (t.char == chrt.empty) {
@@ -169,30 +193,45 @@ class SpawnModifier extends RuleModifier {
   }
 }
 
-/// Cóndor boss (life 2) "Viento": every piece is pushed one step by `[di, dj]`.
-/// A piece blown off the board is removed to its own owner's graveyard. Because
-/// the push is a rigid translation, distinct pieces never collide; processing
-/// the frontier (pieces nearest the push edge) first keeps each destination free
-/// before the next piece arrives.
+/// Cóndor boss (life 2) "Viento": every [everyTurns] of the affected side's turns
+/// a gust pushes every piece one step by `[di, dj]`. A piece blown off the board
+/// is removed to its own owner's graveyard. **Kings are anchored** — the wind
+/// never moves or removes a king (so the sun can't be blown away). Because the
+/// push is a rigid translation, distinct pieces never collide; processing the
+/// frontier (pieces nearest the push edge) first keeps each destination free.
+///
+/// Holds a countdown for the next gust (real-loop only, safe — see [SpawnModifier]).
 class WindModifier extends RuleModifier {
-  const WindModifier(
-      {required this.di, required this.dj, this.side = ModifierSide.both});
+  WindModifier(
+      {required this.di,
+      required this.dj,
+      this.everyTurns = 5,
+      this.side = ModifierSide.both});
 
   final int di;
   final int dj;
+  final int everyTurns;
 
   @override
   final ModifierSide side;
 
+  late int _untilNext = everyTurns; // gust after `everyTurns` turns, then repeat
+
+  /// Turns until the next gust (for UI).
+  int get turnsUntilNext => _untilNext.clamp(0, everyTurns);
+
   @override
   void onTurnStart(GameState gs) {
+    if (--_untilNext > 0) return;
+    _untilNext = everyTurns;
+
     final height = gs.board.length;
     final width = gs.board.isEmpty ? 0 : gs.board[0].length;
 
     final pieces = <Tile>[
       for (final row in gs.board)
         for (final t in row)
-          if (t.char != chrt.empty) t
+          if (t.char != chrt.empty && t.char != chrt.king) t
     ];
     pieces.sort((a, b) =>
         (b.i! * di + b.j! * dj).compareTo(a.i! * di + a.j! * dj));
@@ -252,23 +291,69 @@ class WitherModifier extends RuleModifier {
   }
 }
 
-/// Leñador boss (life 1) "Tala el tablero": the [felled] tiles (`[i, j]` pairs)
-/// may not be entered by the side this modifier applies to (default the
-/// protagonist) — the leñador itself may still step on them.
+/// Leñador boss (life 1) "Tala el tablero": a spreading hazard. On each of the
+/// affected side's turns one new square — adjacent to an already-felled one, or
+/// the board centre if none are felled — is felled for [duration] turns, while
+/// existing felled squares count down back to normal. The affected side (default
+/// the protagonist) may not enter a felled square; felling never removes pieces.
+///
+/// State lives on the tiles ([Tile.felledTurns]), so it travels with the board
+/// through rotation.
 class FelledTilesModifier extends RuleModifier {
-  const FelledTilesModifier(this.felled, {this.side = ModifierSide.protagonist});
+  const FelledTilesModifier(
+      {this.side = ModifierSide.protagonist, this.duration = 2});
 
-  final List<List<int>> felled;
+  final int duration;
 
   @override
   final ModifierSide side;
 
   @override
+  void onTurnStart(GameState gs) {
+    for (final row in gs.board) {
+      for (final t in row) {
+        if (t.felledTurns > 0) t.felledTurns--;
+      }
+    }
+    final height = gs.board.length;
+    final width = gs.board.isEmpty ? 0 : gs.board[0].length;
+    final felled = <Tile>[
+      for (final row in gs.board)
+        for (final t in row)
+          if (t.felledTurns > 0) t
+    ];
+    if (felled.isEmpty) {
+      gs.board[height ~/ 2][width ~/ 2].felledTurns = duration; // seed
+      return;
+    }
+    const dirs = [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1]
+    ];
+    for (final t in felled) {
+      for (final d in dirs) {
+        final ni = t.i! + d[0];
+        final nj = t.j! + d[1];
+        if (nj < 0 || nj >= height || ni < 0 || ni >= width) continue;
+        final n = gs.board[nj][ni];
+        if (n.felledTurns == 0) {
+          n.felledTurns = duration; // spread to a fresh neighbour
+          return;
+        }
+      }
+    }
+  }
+
+  @override
   bool allowsMove(Move move, GameState gs) {
     if (!appliesTo(move.initialTile.owner, gs)) return true;
-    for (final c in felled) {
-      if (c[0] == move.finalTile.i && c[1] == move.finalTile.j) return false;
-    }
-    return true;
+    final fi = move.finalTile.i;
+    final fj = move.finalTile.j;
+    if (fi == null || fj == null) return true;
+    // Read the actual board tile (the move's finalTile may be a lightweight
+    // destination without the felled state).
+    return gs.board[fj][fi].felledTurns == 0;
   }
 }

--- a/lib/app/engine/rule_modifier.dart
+++ b/lib/app/engine/rule_modifier.dart
@@ -74,8 +74,8 @@ abstract class RuleModifier {
 
 /// Joker "doble paso": the affected side's pieces gain a **2-square** option in
 /// each direction they can already move, on top of their normal 1-square moves.
-/// The board has no path/blocking logic (every base move is one exact step), so
-/// a 2-step move simply reaches a farther exact square.
+/// Unlike a bare offset, the 2-step is **blocked by a piece in between** — the
+/// leap needs a clear midpoint, so it can't jump over anything (see [allowsMove]).
 class DoubleStepModifier extends RuleModifier {
   const DoubleStepModifier({this.side = ModifierSide.both});
 
@@ -89,6 +89,26 @@ class DoubleStepModifier extends RuleModifier {
       ...base,
       for (final o in base) [o[0] * 2, o[1] * 2],
     ];
+  }
+
+  @override
+  bool allowsMove(Move move, GameState gs) {
+    if (isFromGraveyard(move.initialTile)) return true;
+    if (!appliesTo(move.initialTile.owner, gs)) return true;
+    final ii = move.initialTile.i, ij = move.initialTile.j;
+    final fi = move.finalTile.i, fj = move.finalTile.j;
+    if (ii == null || ij == null || fi == null || fj == null) return true;
+    final di = fi - ii, dj = fj - ij;
+    // Base moves are single steps (components in -1..1): only a doubled move has
+    // both components even. Anything else isn't a leap, so never blocked here.
+    if (di.isOdd || dj.isOdd) return true;
+    final hi = di ~/ 2, hj = dj ~/ 2;
+    if (hi == 0 && hj == 0) return true;
+    final isLeap = pieceOffsets(move.initialTile.char, move.initialTile.owner)
+        .any((o) => o[0] == hi && o[1] == hj);
+    if (!isLeap) return true;
+    // The square the piece leaps over must be empty.
+    return gs.board[ij + hj][ii + hi].char == chrt.empty;
   }
 }
 
@@ -193,23 +213,22 @@ class SpawnModifier extends RuleModifier {
   }
 }
 
-/// Cóndor boss (life 2) "Viento": every [everyTurns] of the affected side's turns
-/// a gust pushes every piece one step by `[di, dj]`. A piece blown off the board
-/// is removed to its own owner's graveyard. **Kings are anchored** — the wind
-/// never moves or removes a king (so the sun can't be blown away). Because the
-/// push is a rigid translation, distinct pieces never collide; processing the
-/// frontier (pieces nearest the push edge) first keeps each destination free.
+/// Cóndor boss (life 2) "Viento": every [everyTurns] of the caster's turns a gust
+/// blows the **opponent's** pieces one row back — toward their home edge (`+j` in
+/// the caster's frame) and, from the last row, off the board into their own
+/// graveyard. The caster's own pieces are untouched. A piece moves only if the
+/// square ahead is empty; otherwise it stays (so a column shuffles toward the
+/// edge, and anything jammed behind another piece holds). **Kings are anchored** —
+/// never moved, never blown off — so the sun can't be swept away, and a king also
+/// dams the pieces behind it.
+///
+/// The frontier row (highest `j`) is processed first so each freed square opens up
+/// for the piece behind it, letting a packed column cascade a single step.
 ///
 /// Holds a countdown for the next gust (real-loop only, safe — see [SpawnModifier]).
 class WindModifier extends RuleModifier {
-  WindModifier(
-      {required this.di,
-      required this.dj,
-      this.everyTurns = 5,
-      this.side = ModifierSide.both});
+  WindModifier({this.everyTurns = 5, this.side = ModifierSide.both});
 
-  final int di;
-  final int dj;
   final int everyTurns;
 
   @override
@@ -226,33 +245,32 @@ class WindModifier extends RuleModifier {
     _untilNext = everyTurns;
 
     final height = gs.board.length;
-    final width = gs.board.isEmpty ? 0 : gs.board[0].length;
+    if (height == 0) return;
+    final width = gs.board[0].length;
 
-    final pieces = <Tile>[
-      for (final row in gs.board)
-        for (final t in row)
-          if (t.char != chrt.empty && t.char != chrt.king) t
-    ];
-    pieces.sort((a, b) =>
-        (b.i! * di + b.j! * dj).compareTo(a.i! * di + a.j! * dj));
-
-    for (final t in pieces) {
-      final ni = t.i! + di;
-      final nj = t.j! + dj;
-      final char = t.char;
-      final owner = t.owner;
-      t.char = chrt.empty;
-      t.owner = possession.none;
-      if (nj < 0 || nj >= height || ni < 0 || ni >= width) {
-        if (owner == possession.mine) {
-          gs.myGraveyard.add(Tile(char, possession.mine, null, null));
+    for (int j = height - 1; j >= 0; j--) {
+      for (int i = 0; i < width; i++) {
+        final t = gs.board[j][i];
+        if (t.owner != possession.enemy) continue; // only the opponent's pieces
+        if (t.char == chrt.empty || t.char == chrt.king) continue; // king anchored
+        final nj = j + 1;
+        if (nj >= height) {
+          // blown off the back edge -> its own graveyard
+          gs.enemyGraveyard
+              .add(Tile(gs.graveChar(t.char, t.owner), possession.enemy, null, null));
+          t.char = chrt.empty;
+          t.owner = possession.none;
+          t.idleTurns = 0;
         } else {
-          gs.enemyGraveyard.add(Tile(char, possession.enemy, null, null));
+          final dest = gs.board[nj][i];
+          if (dest.char != chrt.empty) continue; // blocked -> holds position
+          dest.char = t.char;
+          dest.owner = t.owner;
+          dest.idleTurns = t.idleTurns;
+          t.char = chrt.empty;
+          t.owner = possession.none;
+          t.idleTurns = 0;
         }
-      } else {
-        final dest = gs.board[nj][ni];
-        dest.char = char;
-        dest.owner = owner;
       }
     }
   }
@@ -281,7 +299,8 @@ class WitherModifier extends RuleModifier {
         }
         t.idleTurns++;
         if (t.idleTurns >= turns) {
-          gs.myGraveyard.add(Tile(t.char, possession.mine, null, null));
+          gs.myGraveyard.add(
+              Tile(gs.graveChar(t.char, t.owner), possession.mine, null, null));
           t.char = chrt.empty;
           t.owner = possession.none;
           t.idleTurns = 0;

--- a/lib/app/engine/rule_modifier.dart
+++ b/lib/app/engine/rule_modifier.dart
@@ -16,13 +16,27 @@ enum ModifierSide { both, protagonist, antagonist }
 /// `(fromI, fromJ)` to `(toI, toJ)` with the normal move animation and only then
 /// commit the change. A `toJ` past the last row means the piece is blown off the
 /// board (into the graveyard) — the slide just carries it off the edge.
+///
+/// [toGrave] marks a movement whose destination is a graveyard, not a board
+/// square (e.g. a Marchitar death): the UI flies the piece to the graveyard
+/// with the capture animation instead of a board-to-board slide.
 class TickMove {
-  const TickMove(this.fromI, this.fromJ, this.toI, this.toJ);
+  const TickMove(this.fromI, this.fromJ, this.toI, this.toJ)
+      : toGrave = false;
+
+  /// A piece leaving the board for its graveyard (no board destination).
+  const TickMove.toGrave(int i, int j)
+      : fromI = i,
+        fromJ = j,
+        toI = i,
+        toJ = j,
+        toGrave = true;
 
   final int fromI;
   final int fromJ;
   final int toI;
   final int toJ;
+  final bool toGrave;
 }
 
 /// A rule change carried by a [GameState] and applied at defined engine hook
@@ -240,9 +254,13 @@ class SpawnModifier extends RuleModifier {
 /// the caster's frame) and, from the last row, off the board into their own
 /// graveyard. The caster's own pieces are untouched. A piece moves only if the
 /// square ahead is empty; otherwise it stays (so a column shuffles toward the
-/// edge, and anything jammed behind another piece holds). **Kings are anchored** —
-/// never moved, never blown off — so the sun can't be swept away, and a king also
-/// dams the pieces behind it.
+/// edge, and anything jammed behind another piece holds).
+///
+/// The **sun (king) is blown like any other piece — except it can never fall off
+/// the board**: on the last row it stays put (the sun can't be swept away), and
+/// because it holds that square it also dams whatever piece is right behind it
+/// (that piece is "retained" by the king). Everywhere else the king shifts one
+/// row back normally.
 ///
 /// The frontier row (highest `j`) is processed first so each freed square opens up
 /// for the piece behind it, letting a packed column cascade a single step.
@@ -279,17 +297,21 @@ class WindModifier extends RuleModifier {
       for (int i = 0; i < width; i++) {
         final t = gs.board[j][i];
         if (t.owner != possession.enemy) continue; // only the opponent's pieces
-        if (t.char == chrt.empty || t.char == chrt.king) continue; // king anchored
+        if (t.char == chrt.empty) continue;
         final nj = j + 1;
         if (nj >= height) {
+          // Back edge: ordinary pieces are blown into the graveyard; the sun
+          // (king) alone can't fall, so it stays put — and, still occupying its
+          // square, it dams the piece right behind it (processed next).
+          if (t.char == chrt.king) continue;
           moves.add(TickMove(i, j, i, nj)); // blown off the back edge
           occupied[j][i] = false;
         } else if (!occupied[nj][i]) {
-          moves.add(TickMove(i, j, i, nj));
+          moves.add(TickMove(i, j, i, nj)); // shifts one row back (king included)
           occupied[nj][i] = true;
           occupied[j][i] = false;
         }
-        // else blocked -> holds position, no move
+        // else blocked (by a piece or an anchored king ahead) -> holds position
       }
     }
     return moves;
@@ -340,6 +362,27 @@ class WitherModifier extends RuleModifier {
 
   @override
   final ModifierSide side;
+
+  /// Report the pieces that will wither *this* tick (their idle clock is one turn
+  /// short of [turns]), so the UI can fly them to the graveyard before the commit.
+  /// Pure — mirrors the aging [onTurnStart] does without mutating.
+  @override
+  List<TickMove> planTurnStart(GameState gs) {
+    final deaths = <TickMove>[];
+    for (final row in gs.board) {
+      for (final t in row) {
+        if (t.owner != possession.mine ||
+            t.char == chrt.empty ||
+            t.char == chrt.king) {
+          continue;
+        }
+        if (t.idleTurns + 1 >= turns) {
+          deaths.add(TickMove.toGrave(t.i!, t.j!));
+        }
+      }
+    }
+    return deaths;
+  }
 
   @override
   void onTurnStart(GameState gs) {

--- a/lib/app/engine/rules.dart
+++ b/lib/app/engine/rules.dart
@@ -176,6 +176,17 @@ List<List<int>> effectiveOffsets(chrt piece, possession owner, GameState gs) {
   return offsets;
 }
 
+/// The character to DISPLAY for [tile] after modifiers (e.g. a piece transformed
+/// to move like the oso also shows the oso sprite). Rendering-only; does not
+/// affect movement or rules.
+chrt effectiveChar(Tile tile, GameState gs) {
+  var c = tile.char;
+  for (final m in gs.modifiers) {
+    if (m.appliesTo(tile.owner, gs)) c = m.displayChar(c, tile.owner);
+  }
+  return c;
+}
+
 bool isValidMovmentPerPiece(Move m, GameState gs, [bool hard = false]) {
   final di = m.finalTile.i! - m.initialTile.i!;
   final dj = m.finalTile.j! - m.initialTile.j!;

--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -6,6 +6,8 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:get/get.dart';
 import 'package:flutter/foundation.dart';
 import '../../../data/enums.dart';
+import '../../../data/sandbox_config.dart';
+import '../../../engine/rule_modifier.dart';
 import '../../../routes/app_pages.dart';
 import '../../../services/database.dart';
 import '../../auth/controllers/auth_controller.dart';
@@ -37,6 +39,14 @@ class HomeController extends GetxController
     await Future.delayed(const Duration(milliseconds: 500));
     Get.toNamed(Routes.MATCH, arguments: mode);
     // isLoading.value = false;
+  }
+
+  /// Debug tool: launch a solo match with a single rule modifier active, to try
+  /// a power/joker by hand. Gated behind `kDebugMode` in the UI.
+  void startSandbox(RuleModifier modifier) async {
+    isLoading.value = true;
+    await Future.delayed(const Duration(milliseconds: 500));
+    Get.toNamed(Routes.MATCH, arguments: SandboxConfig([modifier]));
   }
 
   Future<void> goToUrl(String url) async {

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -5,6 +5,7 @@ import 'package:get/get.dart';
 import 'package:inti_the_inka_chess_game/app/modules/home/views/welcome_view.dart';
 import 'dart:math';
 import '../../../data/enums.dart';
+import '../../../engine/modifier_catalog.dart';
 import '../../../routes/app_pages.dart';
 import '../../../utils/gameObjects/BackgroundController.dart';
 import '../../../utils/utils.dart';
@@ -36,6 +37,36 @@ class HomeView extends GetView<HomeController> with WidgetsBindingObserver {
             child: Obx(() {
               return Text(l.g(diff.name));
             })));
+  }
+
+  /// Debug-only launcher: pick a modifier from the catalog and start a sandbox
+  /// match with it active. Never shown in release builds.
+  void showSandboxPicker() {
+    Get.dialog(
+      SimpleDialog(
+        backgroundColor: brackgroundColorSolid,
+        title: const Text('Sandbox — probar modificador',
+            style: TextStyle(color: Colors.white)),
+        children: [
+          for (final info in modifierCatalog)
+            SimpleDialogOption(
+              onPressed: () {
+                Get.back();
+                controller.startSandbox(info.sample());
+              },
+              child: ListTile(
+                title: Text(info.name,
+                    style: const TextStyle(color: Colors.white)),
+                subtitle: Text(
+                    '${info.description}\n[${info.uses.map((u) => u.name).join(', ')}]'
+                    '${info.source == null ? '' : ' — ${info.source}'}',
+                    style: const TextStyle(color: Colors.white54)),
+                isThreeLine: true,
+              ),
+            ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -390,6 +421,17 @@ class HomeView extends GetView<HomeController> with WidgetsBindingObserver {
         ),
       ),
       floatingActionButton: Stack(children: [
+        if (kDebugMode)
+          Positioned(
+            left: 0,
+            bottom: 0,
+            child: FloatingActionButton.small(
+              heroTag: 'sandbox',
+              backgroundColor: brackgroundColor,
+              onPressed: showSandboxPicker,
+              child: const Icon(Icons.science, color: Colors.white),
+            ),
+          ),
         Obx(
           () => AnimatedPositioned(
             right: controller.isLoading.value ||

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -463,6 +463,17 @@ class HomeView extends GetView<HomeController> with WidgetsBindingObserver {
               child: const Icon(Icons.science, color: Colors.white),
             ),
           ),
+        if (kDebugMode)
+          Positioned(
+            left: 0,
+            bottom: 56,
+            child: FloatingActionButton.small(
+              heroTag: 'graveyard-flight-sandbox',
+              backgroundColor: brackgroundColor,
+              onPressed: () => Get.toNamed(Routes.GRAVEYARD_SANDBOX),
+              child: const Icon(Icons.flight_takeoff, color: Colors.white),
+            ),
+          ),
         Obx(
           () => AnimatedPositioned(
             right: controller.isLoading.value ||

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -6,6 +6,7 @@ import 'package:inti_the_inka_chess_game/app/modules/home/views/welcome_view.dar
 import 'dart:math';
 import '../../../data/enums.dart';
 import '../../../engine/modifier_catalog.dart';
+import '../../../engine/rule_modifier.dart';
 import '../../../routes/app_pages.dart';
 import '../../../utils/gameObjects/BackgroundController.dart';
 import '../../../utils/utils.dart';
@@ -52,7 +53,7 @@ class HomeView extends GetView<HomeController> with WidgetsBindingObserver {
             SimpleDialogOption(
               onPressed: () {
                 Get.back();
-                controller.startSandbox(info.sample());
+                _pickSandboxSide(info);
               },
               child: ListTile(
                 title: Text(info.name,
@@ -62,6 +63,36 @@ class HomeView extends GetView<HomeController> with WidgetsBindingObserver {
                     '${info.source == null ? '' : ' — ${info.source}'}',
                     style: const TextStyle(color: Colors.white54)),
                 isThreeLine: true,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  /// Second step: choose which side the picked modifier applies to.
+  void _pickSandboxSide(ModifierInfo info) {
+    const options = {
+      'Tú (protagonista)': ModifierSide.protagonist,
+      'Enemigo (IA)': ModifierSide.antagonist,
+      'Ambos': ModifierSide.both,
+    };
+    Get.dialog(
+      SimpleDialog(
+        backgroundColor: brackgroundColorSolid,
+        title: Text('${info.name} — aplicar a',
+            style: const TextStyle(color: Colors.white)),
+        children: [
+          for (final entry in options.entries)
+            SimpleDialogOption(
+              onPressed: () {
+                Get.back();
+                controller.startSandbox(info.build(entry.value));
+              },
+              child: Text(
+                entry.key +
+                    (entry.value == info.defaultSide ? '  ★' : ''),
+                style: const TextStyle(color: Colors.white),
               ),
             ),
         ],

--- a/lib/app/modules/match/controllers/match_controller.dart
+++ b/lib/app/modules/match/controllers/match_controller.dart
@@ -584,16 +584,11 @@ class MatchController extends GetxController with WidgetsBindingObserver {
   // never just teleports.
   Future<void> _runTurnTick() async {
     if (gs.value!.modifiers.isEmpty) return;
-    try {
-      final reveals = await _animateTickMoves(gs.value!.planTurnStart());
-      gs.value!.applyTurnStart(); // commit while any death curtain is up
-      gs.update((val) => val);
-      await Future.wait(reveals); // let the graveyard reveals finish
-    } finally {
-      // Never leave a piece hidden (its flight may have failed) — that would
-      // strand the sprite and, upstream, keep isAnimating stuck.
-      _clearHiddenTiles();
-    }
+    final reveals = await _animateTickMoves(gs.value!.planTurnStart());
+    gs.value!.applyTurnStart(); // commit while any death curtain is up
+    gs.update((val) => val);
+    await Future.wait(reveals); // let the graveyard reveals finish
+    _clearHiddenTiles();
   }
 
   // Animates every piece a per-turn effect is about to move, then returns so the
@@ -645,9 +640,10 @@ class MatchController extends GetxController with WidgetsBindingObserver {
     final player receiver = owner == possession.mine
         ? playersTurn
         : (playersTurn == player.white ? player.black : player.white);
-    final ctx = Get.context;
     final GlobalKey? fromKey = _tileKeys['$i,$j'];
     final GlobalKey? toKey = _graveKeys[receiver];
+    // Use the source tile's own context so the flight can find the app overlay.
+    final ctx = fromKey?.currentContext ?? Get.context;
     if (ctx == null || fromKey == null || toKey == null) {
       onArrive();
       return;
@@ -659,16 +655,21 @@ class MatchController extends GetxController with WidgetsBindingObserver {
     // again for an online guest — so a piece flips iff exactly one applies.
     final bool flip = (receiver == player.black) ^
         (gamemode == gameMode.online && !isHost.value);
-    await flyToGraveyard(
-      ctx,
-      fromKey: fromKey,
-      toKey: toKey,
-      piece: getCharAsset(buried, receiver, false),
-      rotate: flip,
-      onArrive: onArrive,
-      duration:
-          Duration(milliseconds: gamemode == gameMode.training ? 100 : 800),
-    );
+    // Never let a flight failure block the turn (it's awaited inside play()).
+    try {
+      await flyToGraveyard(
+        ctx,
+        fromKey: fromKey,
+        toKey: toKey,
+        piece: getCharAsset(buried, receiver, false),
+        rotate: flip,
+        onArrive: onArrive,
+        duration:
+            Duration(milliseconds: gamemode == gameMode.training ? 100 : 800),
+      );
+    } catch (_) {
+      onArrive();
+    }
   }
 
   void _clearHiddenTiles() {

--- a/lib/app/modules/match/controllers/match_controller.dart
+++ b/lib/app/modules/match/controllers/match_controller.dart
@@ -8,8 +8,10 @@ import 'package:inti_the_inka_chess_game/app/modules/match/controllers/tile_cont
 
 import '../../../data/enums.dart';
 import '../../../data/matchDom.dart';
+import '../../../data/sandbox_config.dart';
 import '../../../data/usefullData.dart';
 import '../../../data/userDom.dart';
+import '../../../engine/rule_modifier.dart';
 import '../../../routes/app_pages.dart';
 import '../../../services/database.dart';
 import '../../../utils/gameObjects/gameState.dart';
@@ -29,7 +31,14 @@ class MatchController extends GetxController with WidgetsBindingObserver {
   LanguageController l = Get.find<LanguageController>();
 
   final homeController = Get.find<HomeController>();
-  final gameMode gamemode = Get.arguments ?? gameMode.vs;
+
+  // The match route argument is normally a [gameMode]. A [SandboxConfig] instead
+  // launches a solo match with rule modifiers active (debug tool).
+  late final gameMode gamemode =
+      Get.arguments is SandboxConfig ? gameMode.solo : (Get.arguments ?? gameMode.vs);
+  late final List<RuleModifier> _modifiers = Get.arguments is SandboxConfig
+      ? (Get.arguments as SandboxConfig).modifiers
+      : const [];
 
   Rx<int> wScore = 0.obs, bScore = 0.obs;
   final selectedTile = Rxn<Tile>();
@@ -276,6 +285,7 @@ class MatchController extends GetxController with WidgetsBindingObserver {
         gs.update((val) => val!.changeGameState(move));
         gs.value!.rotate();
         togglePlayersTurn();
+        _runTurnTick(); // apply per-turn modifier effects for the new mover
       }
       restarSelected(tile);
       highlightAvailableOptions();
@@ -489,7 +499,17 @@ class MatchController extends GetxController with WidgetsBindingObserver {
       enemyGraveyard: <Tile>[],
       // enemyGraveyard: <Tile>[Tile(chrt.pawn, possession.enemy, null, null)],
       myGraveyard: <Tile>[],
+      modifiers: _modifiers,
     );
+  }
+
+  // Runs the active modifiers' per-turn effects (spawn/wither/wind) at the start
+  // of the side-to-move's turn, then repaints the board. No-op without modifiers,
+  // so vanilla matches are untouched.
+  void _runTurnTick() {
+    if (gs.value!.modifiers.isEmpty) return;
+    gs.value!.applyTurnStart();
+    gs.update((val) => val);
   }
 
   void startTimer() {

--- a/lib/app/modules/match/controllers/match_controller.dart
+++ b/lib/app/modules/match/controllers/match_controller.dart
@@ -584,11 +584,16 @@ class MatchController extends GetxController with WidgetsBindingObserver {
   // never just teleports.
   Future<void> _runTurnTick() async {
     if (gs.value!.modifiers.isEmpty) return;
-    final reveals = await _animateTickMoves(gs.value!.planTurnStart());
-    gs.value!.applyTurnStart(); // commit while any death curtain is up
-    gs.update((val) => val);
-    await Future.wait(reveals); // let the graveyard reveals finish
-    _clearHiddenTiles();
+    try {
+      final reveals = await _animateTickMoves(gs.value!.planTurnStart());
+      gs.value!.applyTurnStart(); // commit while any death curtain is up
+      gs.update((val) => val);
+      await Future.wait(reveals); // let the graveyard reveals finish
+    } finally {
+      // Never leave a piece hidden (its flight may have failed) — that would
+      // strand the sprite and, upstream, keep isAnimating stuck.
+      _clearHiddenTiles();
+    }
   }
 
   // Animates every piece a per-turn effect is about to move, then returns so the

--- a/lib/app/modules/match/controllers/match_controller.dart
+++ b/lib/app/modules/match/controllers/match_controller.dart
@@ -21,6 +21,7 @@ import '../../../utils/juice.dart';
 import '../../../utils/utils.dart';
 import '../../home/controllers/home_controller.dart';
 import '../../language/controllers/language_controller.dart';
+import '../widgets/graveyard_flight.dart';
 import 'GraveyardController.dart';
 import 'ai_controller.dart';
 import 'clock_controller.dart';
@@ -42,6 +43,21 @@ class MatchController extends GetxController with WidgetsBindingObserver {
 
   Rx<int> wScore = 0.obs, bScore = 0.obs;
   final selectedTile = Rxn<Tile>();
+
+  // --- Graveyard-flight plumbing (measured, magic-number-free animations) ---
+  // A stable GlobalKey per board grid slot "i,j" and per graveyard [player], so
+  // [flyToGraveyard] can measure real on-screen rects. Board slots are reused
+  // across rotations (one tile per slot per frame), so identity stays unique.
+  final Map<String, GlobalKey> _tileKeys = {};
+  final Map<player, GlobalKey> _graveKeys = {};
+  // Board slots whose piece is mid-flight to a graveyard: rendered empty so the
+  // overlay copy isn't duplicated by the still-present board piece.
+  final Set<String> _hiddenTiles = {};
+
+  GlobalKey tileKey(int? i, int? j) =>
+      _tileKeys.putIfAbsent('$i,$j', () => GlobalKey());
+  GlobalKey graveKey(player p) => _graveKeys.putIfAbsent(p, () => GlobalKey());
+  bool isTileHidden(int? i, int? j) => _hiddenTiles.contains('$i,$j');
 
   late player playersTurn = player.white;
   player winner = player.none;
@@ -568,9 +584,11 @@ class MatchController extends GetxController with WidgetsBindingObserver {
   // never just teleports.
   Future<void> _runTurnTick() async {
     if (gs.value!.modifiers.isEmpty) return;
-    await _animateTickMoves(gs.value!.planTurnStart());
-    gs.value!.applyTurnStart();
+    final reveals = await _animateTickMoves(gs.value!.planTurnStart());
+    gs.value!.applyTurnStart(); // commit while any death curtain is up
     gs.update((val) => val);
+    await Future.wait(reveals); // let the graveyard reveals finish
+    _clearHiddenTiles();
   }
 
   // Animates every piece a per-turn effect is about to move, then returns so the
@@ -579,35 +597,79 @@ class MatchController extends GetxController with WidgetsBindingObserver {
   // owner's graveyard with the capture animation. Wind pieces are enemy-owned,
   // whose tile is drawn inside a 180° RotatedBox, so a slide is fed reversed
   // (destination→source) to cancel that rotation.
-  Future<void> _animateTickMoves(List<TickMove> moves) async {
-    if (moves.isEmpty) return;
-    // Let the just-rotated board finish building so each source tile's
-    // TileController is registered before we look it up.
+  Future<List<Future>> _animateTickMoves(List<TickMove> moves) async {
+    if (moves.isEmpty) return const [];
+    // Let the just-rotated board finish building so each source tile is mounted.
     await WidgetsBinding.instance.endOfFrame;
-    final futures = <Future>[];
-    // Deaths stack onto the graveyard's current end, in report order.
-    int mineGrave = gs.value!.myGraveyard.length;
-    int enemyGrave = gs.value!.enemyGraveyard.length;
+    final awaitNow = <Future>[]; // slides + death landings (before commit)
+    final reveals = <Future>[]; // death curtain retracts (after commit)
     for (final mv in moves) {
       final t = gs.value!.board[mv.fromJ][mv.fromI];
+      if (mv.toGrave) {
+        // Marchitar (and any future in-place death): fly to the graveyard.
+        final landed = Completer<void>();
+        reveals.add(_flyBoardPieceToGrave(mv.fromI, mv.fromJ, t.char, t.owner,
+            onArrive: () {
+          if (!landed.isCompleted) landed.complete();
+        }));
+        awaitNow.add(landed.future);
+        continue;
+      }
       final tag = t.toString();
       if (!Get.isRegistered<TileController>(tag: tag)) continue;
       final tc = Get.find<TileController>(tag: tag);
       final bool enemy = t.owner == possession.enemy;
-      if (mv.toGrave) {
-        // Marchitar (and any future in-place death): fly to the piece's own
-        // graveyard. `-1 - j` targets the near graveyard; the friendly-piece
-        // flag pre-negates for the missing tile rotation.
-        final int slot = enemy ? enemyGrave++ : mineGrave++;
-        futures.add(tc.animateTile(
-            mv.fromI, -1 - mv.fromJ, null, null, slot, !enemy));
-        continue;
-      }
-      futures.add(enemy
+      awaitNow.add(enemy
           ? tc.animateTile(mv.toI, mv.toJ, mv.fromI, mv.fromJ)
           : tc.animateTile(mv.fromI, mv.fromJ, mv.toI, mv.toJ));
     }
-    await Future.wait(futures);
+    await Future.wait(awaitNow);
+    return reveals;
+  }
+
+  // Flies a board piece at (i,j) to its owner's graveyard: hides the board copy
+  // (so the overlay isn't duplicated), launches the overlay flight, and returns
+  // the reveal future. [onArrive] fires when the piece is hidden behind the
+  // risen curtain — the moment to commit the state so the graveyard add stays
+  // covered until the reveal.
+  Future<void> _flyBoardPieceToGrave(
+      int i, int j, chrt char, possession owner,
+      {required VoidCallback onArrive}) async {
+    // A piece's own graveyard is the mover's (playersTurn) side; an enemy piece
+    // goes to the opponent's.
+    final player receiver = owner == possession.mine
+        ? playersTurn
+        : (playersTurn == player.white ? player.black : player.white);
+    final ctx = Get.context;
+    final GlobalKey? fromKey = _tileKeys['$i,$j'];
+    final GlobalKey? toKey = _graveKeys[receiver];
+    if (ctx == null || fromKey == null || toKey == null) {
+      onArrive();
+      return;
+    }
+    _hiddenTiles.add('$i,$j');
+    gs.update((val) => val);
+    final chrt buried = gs.value!.graveChar(char, owner);
+    // The graveyard strip flips black (top) pieces 180°; the whole zone flips
+    // again for an online guest — so a piece flips iff exactly one applies.
+    final bool flip = (receiver == player.black) ^
+        (gamemode == gameMode.online && !isHost.value);
+    await flyToGraveyard(
+      ctx,
+      fromKey: fromKey,
+      toKey: toKey,
+      piece: getCharAsset(buried, receiver, false),
+      rotate: flip,
+      onArrive: onArrive,
+      duration:
+          Duration(milliseconds: gamemode == gameMode.training ? 100 : 800),
+    );
+  }
+
+  void _clearHiddenTiles() {
+    if (_hiddenTiles.isEmpty) return;
+    _hiddenTiles.clear();
+    gs.update((val) => val);
   }
 
   void startTimer() {

--- a/lib/app/modules/match/controllers/match_controller.dart
+++ b/lib/app/modules/match/controllers/match_controller.dart
@@ -285,7 +285,7 @@ class MatchController extends GetxController with WidgetsBindingObserver {
         gs.update((val) => val!.changeGameState(move));
         gs.value!.rotate();
         togglePlayersTurn();
-        _runTurnTick(); // apply per-turn modifier effects for the new mover
+        await _runTurnTick(); // animate + apply per-turn effects for the new mover
       }
       restarSelected(tile);
       highlightAvailableOptions();
@@ -540,11 +540,38 @@ class MatchController extends GetxController with WidgetsBindingObserver {
 
   // Runs the active modifiers' per-turn effects (spawn/wither/wind) at the start
   // of the side-to-move's turn, then repaints the board. No-op without modifiers,
-  // so vanilla matches are untouched.
-  void _runTurnTick() {
+  // so vanilla matches are untouched. Any piece the effect moves (e.g. a Viento
+  // gust) is first slid with the normal move animation, then committed — so it
+  // never just teleports.
+  Future<void> _runTurnTick() async {
     if (gs.value!.modifiers.isEmpty) return;
+    await _animateTickMoves(gs.value!.planTurnStart());
     gs.value!.applyTurnStart();
     gs.update((val) => val);
+  }
+
+  // Slides every piece a per-turn effect is about to move from its current tile
+  // to the destination, using the same translate animation as an ordinary move,
+  // then returns so the state change can be committed. Wind pieces are enemy-
+  // owned, whose tile is drawn inside a 180° RotatedBox, so the translation is
+  // fed reversed (destination→source) to cancel that rotation.
+  Future<void> _animateTickMoves(List<TickMove> moves) async {
+    if (moves.isEmpty) return;
+    // Let the just-rotated board finish building so each source tile's
+    // TileController is registered before we look it up.
+    await WidgetsBinding.instance.endOfFrame;
+    final futures = <Future>[];
+    for (final mv in moves) {
+      final t = gs.value!.board[mv.fromJ][mv.fromI];
+      final tag = t.toString();
+      if (!Get.isRegistered<TileController>(tag: tag)) continue;
+      final tc = Get.find<TileController>(tag: tag);
+      final bool enemy = t.owner == possession.enemy;
+      futures.add(enemy
+          ? tc.animateTile(mv.toI, mv.toJ, mv.fromI, mv.fromJ)
+          : tc.animateTile(mv.fromI, mv.fromJ, mv.toI, mv.toJ));
+    }
+    await Future.wait(futures);
   }
 
   void startTimer() {

--- a/lib/app/modules/match/controllers/match_controller.dart
+++ b/lib/app/modules/match/controllers/match_controller.dart
@@ -306,7 +306,8 @@ class MatchController extends GetxController with WidgetsBindingObserver {
         chrt.empty) {
       // "Invertir posesión": the captured piece returns to its owner, so it
       // lands in the OPPONENT's graveyard — animate that one's reveal, not the
-      // captor's, otherwise the wrong panel opens.
+      // captor's, otherwise the wrong panel opens, and fly the piece to the far
+      // graveyard instead of the captor's.
       final bool returnsToOwner = gs.value!.modifiers.any((m) =>
           m.appliesTo(possession.mine, gs.value!) &&
           m.returnsCapturedToOwner());
@@ -315,15 +316,20 @@ class MatchController extends GetxController with WidgetsBindingObserver {
           : playersTurn;
       GraveyardController gyController =
           Get.find<GraveyardController>(tag: receiver.name);
-      int length = gyController.getGraveyard(receiver).length;
-      TileController takenTileController =
-          Get.find<TileController>(tag: move.finalTile.toString());
-      takenTileController.flash();
+      int slot = gyController.getGraveyard(receiver).length;
       Juice.capture();
-      takenTileController.animateTile(
-          move.finalTile.i!, -1 - move.finalTile.j!, null, null, length);
+      // The piece the mover landed on.
+      _flyCapturedToGrave(move.finalTile.toString(), move.finalTile.i!,
+          move.finalTile.j!, slot, far: returnsToOwner);
+      // "Embestida": the extra pieces the strike clears fly to the same
+      // graveyard, stacking on the following slots (matching the order the
+      // engine buries them in [GameState.applyExtraCaptures]).
+      for (final c in _areaCaptureTiles(move)) {
+        slot++;
+        _flyCapturedToGrave(gs.value!.board[c[1]][c[0]].toString(), c[0], c[1],
+            slot, far: returnsToOwner);
+      }
       gyController.animateGraveyard();
-      _flashAreaCaptures(move);
     }
     if (isFromGraveyard(move.initialTile)) {
       GraveyardController gyController =
@@ -344,11 +350,15 @@ class MatchController extends GetxController with WidgetsBindingObserver {
     }
   }
 
-  // Give the "Embestida" (area capture) the same gold-ring flash as a normal
-  // capture, on every enemy piece the strike will also clear — so they don't
-  // just silently vanish. Purely cosmetic; the engine does the actual clearing.
-  void _flashAreaCaptures(Move move) {
+  // The board tiles an "Embestida" (area capture) will also clear as `[i, j]`
+  // pairs, in the exact order the engine buries them
+  // ([GameState.applyExtraCaptures]): each active modifier's [extraCaptures],
+  // keeping only on-board enemy non-king tiles, de-duplicated (the engine skips
+  // an already-cleared square). Used to fly them to the graveyard.
+  List<List<int>> _areaCaptureTiles(Move move) {
     final g = gs.value!;
+    final tiles = <List<int>>[];
+    final seen = <String>{};
     for (final m in g.modifiers) {
       if (!m.appliesTo(possession.mine, g)) continue;
       for (final c in m.extraCaptures(move, g)) {
@@ -362,11 +372,24 @@ class MatchController extends GetxController with WidgetsBindingObserver {
             t.char == chrt.king) {
           continue;
         }
-        if (Get.isRegistered<TileController>(tag: t.toString())) {
-          Get.find<TileController>(tag: t.toString()).flash();
-        }
+        if (seen.add('$i,$j')) tiles.add([i, j]);
       }
     }
+    return tiles;
+  }
+
+  // Flash a captured (enemy) tile gold and fly it to the graveyard with the same
+  // slide+shrink as a normal capture. [far] sends it to the OPPONENT's graveyard
+  // (used by "invertir posesión"): the captured piece is drawn 180°-rotated, so
+  // the near graveyard is reached with a downward `-1 - j`; the far one needs an
+  // upward target instead.
+  void _flyCapturedToGrave(String tag, int i, int j, int slot,
+      {required bool far}) {
+    if (!Get.isRegistered<TileController>(tag: tag)) return;
+    final tc = Get.find<TileController>(tag: tag);
+    tc.flash();
+    final int ij = far ? (gs.value!.board.length - j) : (-1 - j);
+    tc.animateTile(i, ij, null, null, slot);
   }
 
   onTapTile(Tile tile) async {
@@ -550,23 +573,36 @@ class MatchController extends GetxController with WidgetsBindingObserver {
     gs.update((val) => val);
   }
 
-  // Slides every piece a per-turn effect is about to move from its current tile
-  // to the destination, using the same translate animation as an ordinary move,
-  // then returns so the state change can be committed. Wind pieces are enemy-
-  // owned, whose tile is drawn inside a 180° RotatedBox, so the translation is
-  // fed reversed (destination→source) to cancel that rotation.
+  // Animates every piece a per-turn effect is about to move, then returns so the
+  // state change can be committed — so nothing ever teleports. A board slide
+  // reuses the ordinary-move translate; a [TickMove.toGrave] death flies to the
+  // owner's graveyard with the capture animation. Wind pieces are enemy-owned,
+  // whose tile is drawn inside a 180° RotatedBox, so a slide is fed reversed
+  // (destination→source) to cancel that rotation.
   Future<void> _animateTickMoves(List<TickMove> moves) async {
     if (moves.isEmpty) return;
     // Let the just-rotated board finish building so each source tile's
     // TileController is registered before we look it up.
     await WidgetsBinding.instance.endOfFrame;
     final futures = <Future>[];
+    // Deaths stack onto the graveyard's current end, in report order.
+    int mineGrave = gs.value!.myGraveyard.length;
+    int enemyGrave = gs.value!.enemyGraveyard.length;
     for (final mv in moves) {
       final t = gs.value!.board[mv.fromJ][mv.fromI];
       final tag = t.toString();
       if (!Get.isRegistered<TileController>(tag: tag)) continue;
       final tc = Get.find<TileController>(tag: tag);
       final bool enemy = t.owner == possession.enemy;
+      if (mv.toGrave) {
+        // Marchitar (and any future in-place death): fly to the piece's own
+        // graveyard. `-1 - j` targets the near graveyard; the friendly-piece
+        // flag pre-negates for the missing tile rotation.
+        final int slot = enemy ? enemyGrave++ : mineGrave++;
+        futures.add(tc.animateTile(
+            mv.fromI, -1 - mv.fromJ, null, null, slot, !enemy));
+        continue;
+      }
       futures.add(enemy
           ? tc.animateTile(mv.toI, mv.toJ, mv.fromI, mv.fromJ)
           : tc.animateTile(mv.fromI, mv.fromJ, mv.toI, mv.toJ));

--- a/lib/app/modules/match/controllers/match_controller.dart
+++ b/lib/app/modules/match/controllers/match_controller.dart
@@ -304,9 +304,18 @@ class MatchController extends GetxController with WidgetsBindingObserver {
   animateTiles(Move move) async {
     if (gs.value!.board[move.finalTile.j!][move.finalTile.i!].char !=
         chrt.empty) {
+      // "Invertir posesión": the captured piece returns to its owner, so it
+      // lands in the OPPONENT's graveyard — animate that one's reveal, not the
+      // captor's, otherwise the wrong panel opens.
+      final bool returnsToOwner = gs.value!.modifiers.any((m) =>
+          m.appliesTo(possession.mine, gs.value!) &&
+          m.returnsCapturedToOwner());
+      final player receiver = returnsToOwner
+          ? (playersTurn == player.white ? player.black : player.white)
+          : playersTurn;
       GraveyardController gyController =
-          Get.find<GraveyardController>(tag: playersTurn.name);
-      int length = gyController.getGraveyard(playersTurn).length;
+          Get.find<GraveyardController>(tag: receiver.name);
+      int length = gyController.getGraveyard(receiver).length;
       TileController takenTileController =
           Get.find<TileController>(tag: move.finalTile.toString());
       takenTileController.flash();
@@ -314,6 +323,7 @@ class MatchController extends GetxController with WidgetsBindingObserver {
       takenTileController.animateTile(
           move.finalTile.i!, -1 - move.finalTile.j!, null, null, length);
       gyController.animateGraveyard();
+      _flashAreaCaptures(move);
     }
     if (isFromGraveyard(move.initialTile)) {
       GraveyardController gyController =
@@ -331,6 +341,31 @@ class MatchController extends GetxController with WidgetsBindingObserver {
           Get.find<TileController>(tag: move.initialTile.toString());
       await tileController.animateTile(move.initialTile.i!, move.initialTile.j!,
           move.finalTile.i, move.finalTile.j);
+    }
+  }
+
+  // Give the "Embestida" (area capture) the same gold-ring flash as a normal
+  // capture, on every enemy piece the strike will also clear — so they don't
+  // just silently vanish. Purely cosmetic; the engine does the actual clearing.
+  void _flashAreaCaptures(Move move) {
+    final g = gs.value!;
+    for (final m in g.modifiers) {
+      if (!m.appliesTo(possession.mine, g)) continue;
+      for (final c in m.extraCaptures(move, g)) {
+        final i = c[0], j = c[1];
+        if (j < 0 || j >= g.board.length || i < 0 || i >= g.board[j].length) {
+          continue;
+        }
+        final t = g.board[j][i];
+        if (t.owner != possession.enemy ||
+            t.char == chrt.empty ||
+            t.char == chrt.king) {
+          continue;
+        }
+        if (Get.isRegistered<TileController>(tag: t.toString())) {
+          Get.find<TileController>(tag: t.toString()).flash();
+        }
+      }
     }
   }
 

--- a/lib/app/modules/match/controllers/tile_controller.dart
+++ b/lib/app/modules/match/controllers/tile_controller.dart
@@ -19,7 +19,8 @@ class TileController extends GetxController
   double fScale = 1;
   double rotation = 0;
 
-  animateTile(int? ii, int? ij, [int? fi, int? fj, int? gyPosition]) async {
+  animateTile(int? ii, int? ij,
+      [int? fi, int? fj, int? gyPosition, bool mineToGrave = false]) async {
     if (ii == null && ij == null) {//from graveyard
       translation =
           Vector3(18 + (-gyPosition! * 47) + fi! * 100, -95 - fj! * 100, 0);
@@ -28,8 +29,13 @@ class TileController extends GetxController
     } else if (fi != null && fj != null) {//normal translation
       translation = Vector3((fi - ii!) * 100, (ij! - fj) * 100, 0);
     } else if (fi == null && fj == null) {//to graveyard
-      translation =
+      // A captured (enemy) piece is drawn inside a 180° RotatedBox, so its
+      // translation is negated on screen; the numbers below are tuned for that.
+      // A friendly piece dying in place (e.g. Marchitar) has NO such rotation,
+      // so we pre-negate the vector to land it in the same on-screen graveyard.
+      final base =
           Vector3(ii! * 100 + 12 + (gyPosition ?? 0) * -47, ij! * 100 + 5, 0);
+      translation = mineToGrave ? -base : base;
       iScale = 1;
       fScale = .4;
       rotation = pi;

--- a/lib/app/modules/match/views/match_view.dart
+++ b/lib/app/modules/match/views/match_view.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../../../data/enums.dart';
 import '../../../data/userDom.dart';
+import '../../../engine/rule_modifier.dart';
 import '../../../routes/app_pages.dart';
 import '../../../utils/gameObjects/BackgroundController.dart';
 import '../../../utils/utils.dart';
@@ -211,6 +212,7 @@ class MatchView extends GetView<MatchController> {
     return Center(
       child: Obx(() {
         return Stack(
+          alignment: Alignment.topCenter,
           children: [
             RotatedBox(
               quarterTurns:
@@ -228,9 +230,29 @@ class MatchView extends GetView<MatchController> {
                 ),
               ),
             ),
+            Positioned(top: 2, child: _windIndicator()),
           ],
         );
       }),
+    );
+  }
+
+  // Debug/campaign feedback: shows the countdown to the next "Viento" gust when
+  // a WindModifier is active. Empty otherwise.
+  Widget _windIndicator() {
+    final gs = controller.gs.value;
+    if (gs == null) return const SizedBox.shrink();
+    final winds = gs.modifiers.whereType<WindModifier>();
+    if (winds.isEmpty) return const SizedBox.shrink();
+    final n = winds.first.turnsUntilNext;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: brackgroundColorSolid.withOpacity(0.85),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text('🌬️ Ventisca en $n',
+          style: const TextStyle(color: Colors.white, fontSize: 12)),
     );
   }
 

--- a/lib/app/modules/match/widgets/ChessTile.dart
+++ b/lib/app/modules/match/widgets/ChessTile.dart
@@ -3,6 +3,8 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:inti_the_inka_chess_game/app/modules/match/views/match_view.dart';
+import '../../../engine/rule_modifier.dart';
+import '../../../engine/rules.dart';
 import '../../../utils/gameObjects/tile.dart';
 import '../../../utils/utils.dart';
 import '../../../data/enums.dart';
@@ -46,6 +48,13 @@ class ChessTile extends GetView {
     return player.black;
   }
 
+  // The character to draw — may differ from tile.char when a modifier transforms
+  // the piece's appearance (e.g. "todas se vuelven osos").
+  chrt displayCharOf() {
+    final gs = matchController.gs.value;
+    return gs == null ? tile.char : effectiveChar(tile, gs);
+  }
+
   @override
   Widget build(BuildContext context) {
     final bool draggable =
@@ -75,7 +84,7 @@ class ChessTile extends GetView {
               child: _maybePulse(
                 tile.isSelected,
                 getCharAsset(
-                    tile.char,
+                    displayCharOf(),
                     getbool(tile.owner == possession.mine)
                         ? player.white
                         : player.black,
@@ -138,8 +147,10 @@ class ChessTile extends GetView {
         child: Stack(
           alignment: Alignment.center,
           children: [
+            if (tile.felledTurns > 0) _felledOverlay(),
             interactive,
             if (tile.isOption) _optionHint(),
+            _witherBadge(),
             _flashOverlay(),
           ],
         ),
@@ -153,7 +164,7 @@ class ChessTile extends GetView {
       width: 90,
       height: 90,
       child: getCharAsset(
-        tile.char,
+        displayCharOf(),
         getbool(tile.owner == possession.mine) ? player.white : player.black,
         true,
       ),
@@ -162,6 +173,55 @@ class ChessTile extends GetView {
 
   Widget _maybePulse(bool active, Widget child) =>
       active ? Pulse(child: child) : child;
+
+  // A "felled" (inaccessible) square: darkened with a no-step mark.
+  Widget _felledOverlay() => IgnorePointer(
+        child: Container(
+          width: 92,
+          height: 92,
+          decoration: BoxDecoration(
+            color: Colors.black.withOpacity(0.45),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: Colors.brown.shade300, width: 2),
+          ),
+          alignment: Alignment.center,
+          child: const Icon(Icons.do_not_step_outlined,
+              color: Colors.white70, size: 26),
+        ),
+      );
+
+  // Small badge counting down the turns until this piece withers ("Marchitar").
+  Widget _witherBadge() {
+    final gs = matchController.gs.value;
+    if (gs == null || tile.char == chrt.empty || tile.char == chrt.king) {
+      return const SizedBox.shrink();
+    }
+    for (final m in gs.modifiers) {
+      if (m is WitherModifier && m.appliesTo(tile.owner, gs)) {
+        final left = m.turns - tile.idleTurns;
+        if (left <= 0) continue;
+        return Positioned(
+          top: 6,
+          right: 6,
+          child: IgnorePointer(
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: Colors.brown.withOpacity(0.9),
+                shape: BoxShape.circle,
+              ),
+              child: Text('$left',
+                  style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                      fontWeight: FontWeight.bold)),
+            ),
+          ),
+        );
+      }
+    }
+    return const SizedBox.shrink();
+  }
 
   // A pulsing hint on a reachable tile: a hollow ring around a capturable
   // piece, or a small dot on an empty square.

--- a/lib/app/modules/match/widgets/ChessTile.dart
+++ b/lib/app/modules/match/widgets/ChessTile.dart
@@ -150,6 +150,7 @@ class ChessTile extends GetView {
             if (tile.felledTurns > 0) _felledOverlay(),
             interactive,
             if (tile.isOption) _optionHint(),
+            _spawnHint(),
             _witherBadge(),
             _flashOverlay(),
           ],
@@ -191,6 +192,9 @@ class ChessTile extends GetView {
       );
 
   // Small badge counting down the turns until this piece withers ("Marchitar").
+  // The whole board is rotated 180° on the opponent's turn, so the badge flips
+  // its anchor corner AND counter-rotates to stay screen-upright and in a
+  // consistent screen position instead of tumbling around each turn.
   Widget _witherBadge() {
     final gs = matchController.gs.value;
     if (gs == null || tile.char == chrt.empty || tile.char == chrt.king) {
@@ -200,25 +204,77 @@ class ChessTile extends GetView {
       if (m is WitherModifier && m.appliesTo(tile.owner, gs)) {
         final left = m.turns - tile.idleTurns;
         if (left <= 0) continue;
+        final bool flip = playersTurn != player.white;
         return Positioned(
-          top: 6,
-          right: 6,
+          top: flip ? null : 6,
+          bottom: flip ? 6 : null,
+          right: flip ? null : 6,
+          left: flip ? 6 : null,
           child: IgnorePointer(
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-              decoration: BoxDecoration(
-                color: Colors.brown.withOpacity(0.9),
-                shape: BoxShape.circle,
+            child: RotatedBox(
+              quarterTurns: flip ? 2 : 0,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: Colors.brown.withOpacity(0.9),
+                  shape: BoxShape.circle,
+                ),
+                child: Text('$left',
+                    style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold)),
               ),
-              child: Text('$left',
-                  style: const TextStyle(
-                      color: Colors.white,
-                      fontSize: 12,
-                      fontWeight: FontWeight.bold)),
             ),
           ),
         );
       }
+    }
+    return const SizedBox.shrink();
+  }
+
+  // A hint on the empty tile where the next "Rebrote" will sprout, so the spawn
+  // isn't a surprise. Shown only in the caster's own frame (where the spawn's
+  // first-empty scan is exact), with a small countdown to the next sprout.
+  Widget _spawnHint() {
+    final gs = matchController.gs.value;
+    if (gs == null || tile.char != chrt.empty) return const SizedBox.shrink();
+    for (final m in gs.modifiers) {
+      if (m is! SpawnModifier) continue;
+      if (!m.appliesTo(possession.mine, gs)) continue;
+      // The modifier fills the first empty tile in board order; only mark THAT
+      // tile so the whole board doesn't light up.
+      Tile? firstEmpty;
+      outer:
+      for (final row in gs.board) {
+        for (final t in row) {
+          if (t.char == chrt.empty) {
+            firstEmpty = t;
+            break outer;
+          }
+        }
+      }
+      if (firstEmpty == null || firstEmpty.i != tile.i || firstEmpty.j != tile.j) {
+        continue;
+      }
+      final bool flip = playersTurn != player.white;
+      return IgnorePointer(
+        child: RotatedBox(
+          quarterTurns: flip ? 2 : 0,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.eco,
+                  color: Colors.lightGreen.withOpacity(0.85), size: 28),
+              Text('${m.turnsUntilNext}',
+                  style: TextStyle(
+                      color: Colors.lightGreen.withOpacity(0.95),
+                      fontSize: 12,
+                      fontWeight: FontWeight.bold)),
+            ],
+          ),
+        ),
+      );
     }
     return const SizedBox.shrink();
   }

--- a/lib/app/modules/match/widgets/ChessTile.dart
+++ b/lib/app/modules/match/widgets/ChessTile.dart
@@ -49,16 +49,21 @@ class ChessTile extends GetView {
   }
 
   // The character to draw — may differ from tile.char when a modifier transforms
-  // the piece's appearance (e.g. "todas se vuelven osos").
+  // the piece's appearance (e.g. "todas se vuelven osos"). Empty while the piece
+  // is mid-flight to a graveyard (drawn by the overlay instead, see
+  // MatchController.isTileHidden), so it isn't shown twice.
   chrt displayCharOf() {
+    if (matchController.isTileHidden(tile.i, tile.j)) return chrt.empty;
     final gs = matchController.gs.value;
     return gs == null ? tile.char : effectiveChar(tile, gs);
   }
 
   @override
   Widget build(BuildContext context) {
-    final bool draggable =
-        tile.char != chrt.empty && tile.owner == possession.mine;
+    final bool hidden = matchController.isTileHidden(tile.i, tile.j);
+    final bool draggable = !hidden &&
+        tile.char != chrt.empty &&
+        tile.owner == possession.mine;
 
     final Widget animatedPiece = AnimatedBuilder(
       animation: tileController.animationController,
@@ -69,7 +74,7 @@ class ChessTile extends GetView {
               width: 80,
               height: 80,
               child: getBase(
-                  tile.owner == possession.none
+                  hidden || tile.owner == possession.none
                       ? player.none
                       : getbool(tile.owner == possession.mine)
                           ? player.white
@@ -142,6 +147,7 @@ class ChessTile extends GetView {
       onWillAcceptWithDetails: (_) => true,
       onAcceptWithDetails: (d) => matchController.onDragDrop(d.data, tile),
       builder: (context, candidate, rejected) => SizedBox(
+        key: matchController.tileKey(tile.i, tile.j),
         width: 100,
         height: 100,
         child: Stack(

--- a/lib/app/modules/match/widgets/Graveyard.dart
+++ b/lib/app/modules/match/widgets/Graveyard.dart
@@ -18,6 +18,7 @@ class Graveyard extends GetView {
   @override
   Widget build(BuildContext context) {
     return Stack(
+      key: matchController.graveKey(p),
       children: [
         ClipRect(
           child: BackdropFilter(

--- a/lib/app/modules/match/widgets/GraveyardTile.dart
+++ b/lib/app/modules/match/widgets/GraveyardTile.dart
@@ -25,6 +25,40 @@ class GraveyardTile extends GetView {
 
   @override
   Widget build(BuildContext context) {
+    // Only the player's own captured pieces can be redeployed (and dragged).
+    final bool draggable = tile.owner == possession.mine;
+
+    final Widget piece = AnimatedBuilder(
+      animation: tileController.animationController,
+      child: getCharAsset(tile.char, p, tile.isSelected),
+      builder: (context, child) {
+        return Center(
+          child: SizedBox(
+            width: 50,
+            height: 50,
+            child: Transform(
+              origin: const Offset(25, 25),
+              transform: Matrix4.compose(
+                tileController.translation * tileController.animationController
+                    .drive(CurveTween(curve: Curves.easeInOutQuint))
+                    .value,
+                math.Quaternion.euler(0, 0,
+                    tileController.rotation * tileController.animationController
+                        .drive(CurveTween(curve: Curves.easeInOutQuint))
+                        .value),
+                math.Vector3.all(tileController.iScale +
+                    (tileController.fScale - tileController.iScale) * tileController.animationController
+                        .drive(CurveTween(curve: Curves.easeInOutQuint))
+                        .value
+                ),
+              ),
+              child: child,
+            ),
+          ),
+        );
+      },
+    );
+
     return InkWell(
       onTap: () => matchController.onTapTile(tile),
       child: Container(
@@ -37,36 +71,24 @@ class GraveyardTile extends GetView {
                 : null,
           ),
           alignment: Alignment.center,
-          child: AnimatedBuilder(
-            animation: tileController.animationController,
-            child: getCharAsset(tile.char, p, tile.isSelected),
-            builder: (context, child) {
-              return Center(
-                child: SizedBox(
-                  width: 50,
-                  height: 50,
-                  child: Transform(
-                    origin: const Offset(25, 25),
-                    transform: Matrix4.compose(
-                      tileController.translation * tileController.animationController
-                          .drive(CurveTween(curve: Curves.easeInOutQuint))
-                          .value,
-                      math.Quaternion.euler(0, 0,
-                          tileController.rotation * tileController.animationController
-                              .drive(CurveTween(curve: Curves.easeInOutQuint))
-                              .value),
-                      math.Vector3.all(tileController.iScale +
-                          (tileController.fScale - tileController.iScale) * tileController.animationController
-                              .drive(CurveTween(curve: Curves.easeInOutQuint))
-                              .value
-                      ),
-                    ),
-                    child: child,
+          // Same gesture as a board piece: the board tiles are DragTargets that
+          // route back through matchController.onDragDrop, so a graveyard piece
+          // can be dropped straight onto an empty square.
+          child: draggable
+              ? Draggable<Tile>(
+                  data: tile,
+                  onDragStarted: () => matchController.selectForDrag(tile),
+                  onDraggableCanceled: (_, __) =>
+                      matchController.cancelSelection(),
+                  feedback: SizedBox(
+                    width: 60,
+                    height: 60,
+                    child: getCharAsset(tile.char, p, true),
                   ),
-                ),
-              );
-            },
-          )),
+                  childWhenDragging: Opacity(opacity: 0.25, child: piece),
+                  child: piece,
+                )
+              : piece),
     );
   }
 }

--- a/lib/app/modules/match/widgets/graveyard_flight.dart
+++ b/lib/app/modules/match/widgets/graveyard_flight.dart
@@ -32,11 +32,17 @@ Future<void> flyToGraveyard(
   Color? curtainColor,
   Duration duration = const Duration(milliseconds: 800),
 }) async {
-  final overlay = Overlay.of(context, rootOverlay: true);
+  // Resolve the overlay from a context that's guaranteed to sit *below* the app
+  // overlay — the source widget's own context — falling back to the passed one.
+  // [Overlay.maybeOf] never throws, so a missing overlay degrades to a no-anim
+  // commit instead of blocking the caller.
+  final ctx = fromKey.currentContext ?? context;
+  final overlay = Overlay.maybeOf(ctx);
   final fromBox = fromKey.currentContext?.findRenderObject() as RenderBox?;
   final toBox = toKey.currentContext?.findRenderObject() as RenderBox?;
-  final overlayBox = overlay.context.findRenderObject() as RenderBox?;
-  if (fromBox == null ||
+  final overlayBox = overlay?.context.findRenderObject() as RenderBox?;
+  if (overlay == null ||
+      fromBox == null ||
       toBox == null ||
       overlayBox == null ||
       !fromBox.hasSize ||
@@ -45,40 +51,48 @@ Future<void> flyToGraveyard(
     return;
   }
 
-  // Everything in the overlay's local space (works even if it doesn't start at
-  // the screen origin).
-  final start = overlayBox
-      .globalToLocal(fromBox.localToGlobal(fromBox.size.center(Offset.zero)));
-  final end = overlayBox
-      .globalToLocal(toBox.localToGlobal(toBox.size.center(Offset.zero)));
-  final curtainRect =
-      overlayBox.globalToLocal(toBox.localToGlobal(Offset.zero)) & toBox.size;
-  final startSize = fromBox.size.shortestSide;
-  final endSize = toBox.size.shortestSide;
-
   final completer = Completer<void>();
-  late OverlayEntry entry;
-  entry = OverlayEntry(
-    builder: (_) => _FlightOverlay(
-      start: start,
-      end: end,
-      startSize: startSize,
-      endSize: endSize,
-      rotate: rotate,
-      curtainRect: curtainRect,
-      curtainColor: curtainColor ?? brackgroundColorSolid,
-      flightDuration: duration,
-      onArrive: onArrive,
-      onDone: () {
-        if (completer.isCompleted) return; // idempotent: never remove twice
-        completer.complete();
-        entry.remove();
-      },
-      child: piece,
-    ),
-  );
+  try {
+    // Everything in the overlay's local space (works even if it doesn't start at
+    // the screen origin).
+    final start = overlayBox
+        .globalToLocal(fromBox.localToGlobal(fromBox.size.center(Offset.zero)));
+    final end = overlayBox
+        .globalToLocal(toBox.localToGlobal(toBox.size.center(Offset.zero)));
+    final curtainRect =
+        overlayBox.globalToLocal(toBox.localToGlobal(Offset.zero)) & toBox.size;
+    final startSize = fromBox.size.shortestSide;
+    final endSize = toBox.size.shortestSide;
 
-  overlay.insert(entry);
+    late OverlayEntry entry;
+    void done() {
+      try {
+        entry.remove();
+      } catch (_) {}
+      if (!completer.isCompleted) completer.complete();
+    }
+
+    entry = OverlayEntry(
+      builder: (_) => _FlightOverlay(
+        start: start,
+        end: end,
+        startSize: startSize,
+        endSize: endSize,
+        rotate: rotate,
+        curtainRect: curtainRect,
+        curtainColor: curtainColor ?? brackgroundColorSolid,
+        flightDuration: duration,
+        onArrive: onArrive,
+        onDone: done,
+        child: piece,
+      ),
+    );
+    overlay.insert(entry);
+  } catch (_) {
+    // Never leave the caller awaiting forever: fall back to an instant commit.
+    onArrive();
+    if (!completer.isCompleted) completer.complete();
+  }
   return completer.future;
 }
 
@@ -139,19 +153,13 @@ class _FlightOverlayState extends State<_FlightOverlay>
 
   Future<void> _land() async {
     // Piece is now fully hidden by the curtain — commit it into the real
-    // graveyard, hold a beat, then reveal. onDone MUST fire no matter what
-    // (even if we get disposed mid-flight), or the caller's future hangs and
-    // the match freezes with isAnimating stuck true.
-    try {
-      if (mounted) setState(() => _landed = true);
-      widget.onArrive();
-      await Future.delayed(const Duration(milliseconds: 120));
-      if (mounted) await _retract.forward();
-    } catch (_) {
-      // swallow — a disposed controller/ticker must not deadlock the caller
-    } finally {
-      widget.onDone();
-    }
+    // graveyard, hold a beat, then reveal.
+    if (mounted) setState(() => _landed = true);
+    widget.onArrive();
+    await Future.delayed(const Duration(milliseconds: 120));
+    if (mounted) await _retract.forward();
+    // Always signal done, even if unmounted, so the caller never hangs.
+    widget.onDone();
   }
 
   @override

--- a/lib/app/modules/match/widgets/graveyard_flight.dart
+++ b/lib/app/modules/match/widgets/graveyard_flight.dart
@@ -4,29 +4,32 @@ import 'dart:ui' show lerpDouble;
 
 import 'package:flutter/material.dart';
 
-/// Flies a piece sprite from any on-screen widget to any graveyard, running
-/// three animations at once:
-///   1. the **translation** from the source rect to the graveyard rect,
-///   2. an optional **180° flip** (a piece landing in the *enemy* graveyard is
-///      drawn upside-down there, so it turns over on the way; a piece going to
-///      its *own* graveyard keeps its orientation), and
-///   3. whatever [onLaunch] kicks off simultaneously — typically the graveyard's
-///      "curtain" reveal that hides the strip for a beat while the piece lands.
+import '../../../data/enums.dart';
+
+/// Flies a piece sprite from any on-screen widget to any graveyard, running the
+/// whole sequence in one full-screen [Overlay] so nothing is left behind the
+/// nested [RotatedBox]es of the board and graveyards:
+///   1. the **translation** from the source rect to the graveyard rect (shrinking
+///      to graveyard size), plus an optional **180° flip** (a piece landing in
+///      the *enemy* graveyard is drawn upside-down, so it turns over on the way;
+///      a piece going to its *own* graveyard keeps its orientation);
+///   2. a **curtain** that rises over the destination graveyard — drawn *above*
+///      the flying piece — and covers it just as it lands;
+///   3. while fully hidden, [onArrive] commits the piece into the real graveyard;
+///   4. the curtain retracts, revealing the strip with the piece settled in.
 ///
 /// Positions come from the live widgets ([fromKey], [toKey]) measured at launch,
-/// so the flight is correct for any board size or layout — there are no tuned
-/// pixel offsets. The flyer lives in the root [Overlay] (absolute screen space),
-/// decoupled from the nested [RotatedBox]es of the board and graveyards.
+/// so it's correct for any board size or layout — there are no tuned offsets.
 ///
-/// Returns when the flight finishes; the caller then commits the piece into the
-/// real graveyard (the overlay flyer is transient and removes itself).
+/// Returns when the curtain finishes retracting.
 Future<void> flyToGraveyard(
   BuildContext context, {
   required GlobalKey fromKey,
   required GlobalKey toKey,
   required Widget piece,
   required bool rotate,
-  VoidCallback? onLaunch,
+  required VoidCallback onArrive,
+  Color? curtainColor,
   Duration duration = const Duration(milliseconds: 800),
 }) async {
   final overlay = Overlay.of(context);
@@ -38,28 +41,34 @@ Future<void> flyToGraveyard(
       overlayBox == null ||
       !fromBox.hasSize ||
       !toBox.hasSize) {
+    onArrive();
     return;
   }
 
-  // Source/target centres in the overlay's local space (works even if the
-  // overlay doesn't start at the screen origin).
+  // Everything in the overlay's local space (works even if it doesn't start at
+  // the screen origin).
   final start = overlayBox
       .globalToLocal(fromBox.localToGlobal(fromBox.size.center(Offset.zero)));
   final end = overlayBox
       .globalToLocal(toBox.localToGlobal(toBox.size.center(Offset.zero)));
+  final curtainRect =
+      overlayBox.globalToLocal(toBox.localToGlobal(Offset.zero)) & toBox.size;
   final startSize = fromBox.size.shortestSide;
   final endSize = toBox.size.shortestSide;
 
   final completer = Completer<void>();
   late OverlayEntry entry;
   entry = OverlayEntry(
-    builder: (_) => _GraveyardFlight(
+    builder: (_) => _FlightOverlay(
       start: start,
       end: end,
       startSize: startSize,
       endSize: endSize,
       rotate: rotate,
-      duration: duration,
+      curtainRect: curtainRect,
+      curtainColor: curtainColor ?? brackgroundColorSolid,
+      flightDuration: duration,
+      onArrive: onArrive,
       onDone: () {
         entry.remove();
         if (!completer.isCompleted) completer.complete();
@@ -68,19 +77,21 @@ Future<void> flyToGraveyard(
     ),
   );
 
-  onLaunch?.call();
   overlay.insert(entry);
   return completer.future;
 }
 
-class _GraveyardFlight extends StatefulWidget {
-  const _GraveyardFlight({
+class _FlightOverlay extends StatefulWidget {
+  const _FlightOverlay({
     required this.start,
     required this.end,
     required this.startSize,
     required this.endSize,
     required this.rotate,
-    required this.duration,
+    required this.curtainRect,
+    required this.curtainColor,
+    required this.flightDuration,
+    required this.onArrive,
     required this.onDone,
     required this.child,
   });
@@ -90,52 +101,106 @@ class _GraveyardFlight extends StatefulWidget {
   final double startSize;
   final double endSize;
   final bool rotate;
-  final Duration duration;
+  final Rect curtainRect;
+  final Color curtainColor;
+  final Duration flightDuration;
+  final VoidCallback onArrive;
   final VoidCallback onDone;
   final Widget child;
 
   @override
-  State<_GraveyardFlight> createState() => _GraveyardFlightState();
+  State<_FlightOverlay> createState() => _FlightOverlayState();
 }
 
-class _GraveyardFlightState extends State<_GraveyardFlight>
-    with SingleTickerProviderStateMixin {
-  late final AnimationController _c =
-      AnimationController(vsync: this, duration: widget.duration);
-  late final Animation<double> _t =
-      CurvedAnimation(parent: _c, curve: Curves.easeInOutQuint);
+class _FlightOverlayState extends State<_FlightOverlay>
+    with TickerProviderStateMixin {
+  // Drives the piece from source to graveyard; the curtain rises over its tail.
+  late final AnimationController _flight =
+      AnimationController(vsync: this, duration: widget.flightDuration);
+  late final Animation<double> _flightT =
+      CurvedAnimation(parent: _flight, curve: Curves.easeInOutQuint);
+  // Retracts the curtain once the piece has landed and been committed.
+  late final AnimationController _retract =
+      AnimationController(vsync: this, duration: const Duration(milliseconds: 350));
+
+  // The curtain starts covering the last 45% of the flight, so it's fully up
+  // exactly as the piece arrives.
+  static const double _coverFrom = 0.55;
+
+  bool _landed = false;
 
   @override
   void initState() {
     super.initState();
-    _c.forward().whenComplete(widget.onDone);
+    _flight.forward().whenComplete(_land);
+  }
+
+  Future<void> _land() async {
+    // Piece is now fully hidden by the curtain — commit it into the real
+    // graveyard, hold a beat, then reveal.
+    setState(() => _landed = true);
+    widget.onArrive();
+    await Future.delayed(const Duration(milliseconds: 120));
+    if (!mounted) return;
+    await _retract.forward();
+    widget.onDone();
   }
 
   @override
   void dispose() {
-    _c.dispose();
+    _flight.dispose();
+    _retract.dispose();
     super.dispose();
+  }
+
+  double get _curtainValue {
+    if (_landed) return 1 - _retract.value; // retracting
+    final v = _flightT.value;
+    return ((v - _coverFrom) / (1 - _coverFrom)).clamp(0.0, 1.0);
   }
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: _t,
-      builder: (context, _) {
-        final v = _t.value;
-        final pos = Offset.lerp(widget.start, widget.end, v)!;
-        final size = lerpDouble(widget.startSize, widget.endSize, v)!;
-        final angle = widget.rotate ? v * pi : 0.0;
-        return Positioned(
-          left: pos.dx - size / 2,
-          top: pos.dy - size / 2,
-          width: size,
-          height: size,
-          child: IgnorePointer(
-            child: Transform.rotate(angle: angle, child: widget.child),
-          ),
-        );
-      },
+    return Positioned.fill(
+      child: IgnorePointer(
+        child: AnimatedBuilder(
+          animation: Listenable.merge([_flight, _retract]),
+          builder: (context, _) {
+            final v = _flightT.value;
+            final pos = Offset.lerp(widget.start, widget.end, v)!;
+            final size = lerpDouble(widget.startSize, widget.endSize, v)!;
+            final angle = widget.rotate ? v * pi : 0.0;
+            return Stack(
+              children: [
+                // The flying piece — hidden once it has landed behind the curtain.
+                if (!_landed)
+                  Positioned(
+                    left: pos.dx - size / 2,
+                    top: pos.dy - size / 2,
+                    width: size,
+                    height: size,
+                    child: Transform.rotate(angle: angle, child: widget.child),
+                  ),
+                // The curtain — always ABOVE the piece, so it covers the landing.
+                Positioned.fromRect(
+                  rect: widget.curtainRect,
+                  child: Center(
+                    child: Transform.scale(
+                      scaleY: _curtainValue,
+                      child: Container(
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(8),
+                          color: widget.curtainColor,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
     );
   }
 }

--- a/lib/app/modules/match/widgets/graveyard_flight.dart
+++ b/lib/app/modules/match/widgets/graveyard_flight.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+import 'dart:math';
+import 'dart:ui' show lerpDouble;
+
+import 'package:flutter/material.dart';
+
+/// Flies a piece sprite from any on-screen widget to any graveyard, running
+/// three animations at once:
+///   1. the **translation** from the source rect to the graveyard rect,
+///   2. an optional **180° flip** (a piece landing in the *enemy* graveyard is
+///      drawn upside-down there, so it turns over on the way; a piece going to
+///      its *own* graveyard keeps its orientation), and
+///   3. whatever [onLaunch] kicks off simultaneously — typically the graveyard's
+///      "curtain" reveal that hides the strip for a beat while the piece lands.
+///
+/// Positions come from the live widgets ([fromKey], [toKey]) measured at launch,
+/// so the flight is correct for any board size or layout — there are no tuned
+/// pixel offsets. The flyer lives in the root [Overlay] (absolute screen space),
+/// decoupled from the nested [RotatedBox]es of the board and graveyards.
+///
+/// Returns when the flight finishes; the caller then commits the piece into the
+/// real graveyard (the overlay flyer is transient and removes itself).
+Future<void> flyToGraveyard(
+  BuildContext context, {
+  required GlobalKey fromKey,
+  required GlobalKey toKey,
+  required Widget piece,
+  required bool rotate,
+  VoidCallback? onLaunch,
+  Duration duration = const Duration(milliseconds: 800),
+}) async {
+  final overlay = Overlay.of(context);
+  final fromBox = fromKey.currentContext?.findRenderObject() as RenderBox?;
+  final toBox = toKey.currentContext?.findRenderObject() as RenderBox?;
+  final overlayBox = overlay.context.findRenderObject() as RenderBox?;
+  if (fromBox == null ||
+      toBox == null ||
+      overlayBox == null ||
+      !fromBox.hasSize ||
+      !toBox.hasSize) {
+    return;
+  }
+
+  // Source/target centres in the overlay's local space (works even if the
+  // overlay doesn't start at the screen origin).
+  final start = overlayBox
+      .globalToLocal(fromBox.localToGlobal(fromBox.size.center(Offset.zero)));
+  final end = overlayBox
+      .globalToLocal(toBox.localToGlobal(toBox.size.center(Offset.zero)));
+  final startSize = fromBox.size.shortestSide;
+  final endSize = toBox.size.shortestSide;
+
+  final completer = Completer<void>();
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (_) => _GraveyardFlight(
+      start: start,
+      end: end,
+      startSize: startSize,
+      endSize: endSize,
+      rotate: rotate,
+      duration: duration,
+      onDone: () {
+        entry.remove();
+        if (!completer.isCompleted) completer.complete();
+      },
+      child: piece,
+    ),
+  );
+
+  onLaunch?.call();
+  overlay.insert(entry);
+  return completer.future;
+}
+
+class _GraveyardFlight extends StatefulWidget {
+  const _GraveyardFlight({
+    required this.start,
+    required this.end,
+    required this.startSize,
+    required this.endSize,
+    required this.rotate,
+    required this.duration,
+    required this.onDone,
+    required this.child,
+  });
+
+  final Offset start;
+  final Offset end;
+  final double startSize;
+  final double endSize;
+  final bool rotate;
+  final Duration duration;
+  final VoidCallback onDone;
+  final Widget child;
+
+  @override
+  State<_GraveyardFlight> createState() => _GraveyardFlightState();
+}
+
+class _GraveyardFlightState extends State<_GraveyardFlight>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _c =
+      AnimationController(vsync: this, duration: widget.duration);
+  late final Animation<double> _t =
+      CurvedAnimation(parent: _c, curve: Curves.easeInOutQuint);
+
+  @override
+  void initState() {
+    super.initState();
+    _c.forward().whenComplete(widget.onDone);
+  }
+
+  @override
+  void dispose() {
+    _c.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _t,
+      builder: (context, _) {
+        final v = _t.value;
+        final pos = Offset.lerp(widget.start, widget.end, v)!;
+        final size = lerpDouble(widget.startSize, widget.endSize, v)!;
+        final angle = widget.rotate ? v * pi : 0.0;
+        return Positioned(
+          left: pos.dx - size / 2,
+          top: pos.dy - size / 2,
+          width: size,
+          height: size,
+          child: IgnorePointer(
+            child: Transform.rotate(angle: angle, child: widget.child),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/app/modules/match/widgets/graveyard_flight.dart
+++ b/lib/app/modules/match/widgets/graveyard_flight.dart
@@ -123,9 +123,10 @@ class _FlightOverlayState extends State<_FlightOverlay>
   late final AnimationController _retract =
       AnimationController(vsync: this, duration: const Duration(milliseconds: 350));
 
-  // The curtain starts covering the last 45% of the flight, so it's fully up
-  // exactly as the piece arrives.
-  static const double _coverFrom = 0.55;
+  // The curtain is fully up by this fraction of the flight and stays up until
+  // the piece lands, so it covers the graveyard (and any state commit the caller
+  // makes on arrival) well before the reveal.
+  static const double _coverBy = 0.7;
 
   bool _landed = false;
 
@@ -155,8 +156,7 @@ class _FlightOverlayState extends State<_FlightOverlay>
 
   double get _curtainValue {
     if (_landed) return 1 - _retract.value; // retracting
-    final v = _flightT.value;
-    return ((v - _coverFrom) / (1 - _coverFrom)).clamp(0.0, 1.0);
+    return (_flightT.value / _coverBy).clamp(0.0, 1.0);
   }
 
   @override

--- a/lib/app/modules/match/widgets/graveyard_flight.dart
+++ b/lib/app/modules/match/widgets/graveyard_flight.dart
@@ -32,7 +32,7 @@ Future<void> flyToGraveyard(
   Color? curtainColor,
   Duration duration = const Duration(milliseconds: 800),
 }) async {
-  final overlay = Overlay.of(context);
+  final overlay = Overlay.of(context, rootOverlay: true);
   final fromBox = fromKey.currentContext?.findRenderObject() as RenderBox?;
   final toBox = toKey.currentContext?.findRenderObject() as RenderBox?;
   final overlayBox = overlay.context.findRenderObject() as RenderBox?;
@@ -70,8 +70,9 @@ Future<void> flyToGraveyard(
       flightDuration: duration,
       onArrive: onArrive,
       onDone: () {
+        if (completer.isCompleted) return; // idempotent: never remove twice
+        completer.complete();
         entry.remove();
-        if (!completer.isCompleted) completer.complete();
       },
       child: piece,
     ),
@@ -138,13 +139,19 @@ class _FlightOverlayState extends State<_FlightOverlay>
 
   Future<void> _land() async {
     // Piece is now fully hidden by the curtain — commit it into the real
-    // graveyard, hold a beat, then reveal.
-    setState(() => _landed = true);
-    widget.onArrive();
-    await Future.delayed(const Duration(milliseconds: 120));
-    if (!mounted) return;
-    await _retract.forward();
-    widget.onDone();
+    // graveyard, hold a beat, then reveal. onDone MUST fire no matter what
+    // (even if we get disposed mid-flight), or the caller's future hangs and
+    // the match freezes with isAnimating stuck true.
+    try {
+      if (mounted) setState(() => _landed = true);
+      widget.onArrive();
+      await Future.delayed(const Duration(milliseconds: 120));
+      if (mounted) await _retract.forward();
+    } catch (_) {
+      // swallow — a disposed controller/ticker must not deadlock the caller
+    } finally {
+      widget.onDone();
+    }
   }
 
   @override

--- a/lib/app/modules/sandbox/graveyard_flight_sandbox.dart
+++ b/lib/app/modules/sandbox/graveyard_flight_sandbox.dart
@@ -27,12 +27,6 @@ class _GraveyardFlightSandboxState extends State<GraveyardFlightSandbox>
   late final List<List<GlobalKey>> _cellKeys = List.generate(
       _rows, (_) => List.generate(_cols, (_) => GlobalKey()));
 
-  // Curtain-reveal controllers, one per graveyard (mirrors GraveyardController).
-  late final AnimationController _topReveal =
-      AnimationController(vsync: this, duration: const Duration(milliseconds: 400));
-  late final AnimationController _bottomReveal =
-      AnimationController(vsync: this, duration: const Duration(milliseconds: 400));
-
   final List<chrt> _topBuried = [];
   final List<chrt> _bottomBuried = [];
 
@@ -54,39 +48,25 @@ class _GraveyardFlightSandboxState extends State<GraveyardFlightSandbox>
     chrt.king,
   ];
 
-  @override
-  void dispose() {
-    _topReveal.dispose();
-    _bottomReveal.dispose();
-    super.dispose();
-  }
-
-  Future<void> _revealCurtain(AnimationController c) async {
-    await c.forward();
-    await Future.delayed(const Duration(milliseconds: 400));
-    await c.reverse();
-    c.reset();
-  }
-
   Future<void> _fly(int i, int j) async {
     final bool toEnemy = _toEnemyGrave;
-    final fromKey = _cellKeys[j][i];
     final toKey = toEnemy ? _topGraveKey : _bottomGraveKey;
-    final reveal = toEnemy ? _topReveal : _bottomReveal;
     // The piece is shown in the destination graveyard's colour.
     final gravePlayer = toEnemy ? player.black : player.white;
+    final piece = _selected;
 
     await flyToGraveyard(
       context,
-      fromKey: fromKey,
+      fromKey: _cellKeys[j][i],
       toKey: toKey,
-      piece: getCharAsset(_selected, gravePlayer, false),
+      piece: getCharAsset(piece, gravePlayer, false),
       rotate: _rotateOverride,
-      onLaunch: () => _revealCurtain(reveal),
+      // Commit the piece while it's hidden behind the curtain.
+      onArrive: () {
+        if (!mounted) return;
+        setState(() => (toEnemy ? _topBuried : _bottomBuried).add(piece));
+      },
     );
-
-    if (!mounted) return;
-    setState(() => (toEnemy ? _topBuried : _bottomBuried).add(_selected));
   }
 
   @override
@@ -102,13 +82,13 @@ class _GraveyardFlightSandboxState extends State<GraveyardFlightSandbox>
           child: Column(
             children: [
               const SizedBox(height: 12),
-              _graveStrip(_topGraveKey, _topReveal, _topBuried, player.black,
+              _graveStrip(_topGraveKey, _topBuried, player.black,
                   'Cementerio enemigo (arriba)'),
               const SizedBox(height: 24),
               _board(),
               const SizedBox(height: 24),
-              _graveStrip(_bottomGraveKey, _bottomReveal, _bottomBuried,
-                  player.white, 'Cementerio propio (abajo)'),
+              _graveStrip(_bottomGraveKey, _bottomBuried, player.white,
+                  'Cementerio propio (abajo)'),
               const SizedBox(height: 24),
               _controls(),
               const SizedBox(height: 24),
@@ -163,58 +143,36 @@ class _GraveyardFlightSandboxState extends State<GraveyardFlightSandbox>
     );
   }
 
-  // A graveyard strip that matches the real one's dimensions + curtain reveal.
-  Widget _graveStrip(GlobalKey key, AnimationController reveal,
-      List<chrt> buried, player p, String label) {
+  // A graveyard strip that matches the real one's dimensions. The reveal curtain
+  // is drawn by flyToGraveyard (in the overlay, above the flying piece).
+  Widget _graveStrip(
+      GlobalKey key, List<chrt> buried, player p, String label) {
     return Column(
       children: [
         Text(label, style: const TextStyle(color: Colors.white70, fontSize: 12)),
         const SizedBox(height: 4),
-        SizedBox(
+        Container(
           key: key,
           width: graveyardTileWide,
           height: graveyardHeight,
-          child: Stack(
-            children: [
-              Container(
-                decoration: BoxDecoration(
-                  border: Border.all(color: brackgroundColor),
-                  color: brackgroundColor,
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: RotatedBox(
-                  quarterTurns: p == player.white ? 0 : 2,
-                  child: ListView(
-                    scrollDirection: Axis.horizontal,
-                    children: [
-                      for (final c in buried)
-                        SizedBox(
-                          width: graveyardHeight,
-                          height: graveyardHeight,
-                          child: getCharAsset(c, p, false),
-                        ),
-                    ],
+          decoration: BoxDecoration(
+            border: Border.all(color: brackgroundColor),
+            color: brackgroundColor,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: RotatedBox(
+            quarterTurns: p == player.white ? 0 : 2,
+            child: ListView(
+              scrollDirection: Axis.horizontal,
+              children: [
+                for (final c in buried)
+                  SizedBox(
+                    width: graveyardHeight,
+                    height: graveyardHeight,
+                    child: getCharAsset(c, p, false),
                   ),
-                ),
-              ),
-              // The curtain that hides the strip while a piece lands.
-              Center(
-                child: AnimatedBuilder(
-                  animation: reveal,
-                  builder: (context, _) => Transform.scale(
-                    scaleY: reveal.value,
-                    child: Container(
-                      width: graveyardTileWide - 4,
-                      height: graveyardHeight - 4,
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(8),
-                        color: brackgroundColorSolid,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ],

--- a/lib/app/modules/sandbox/graveyard_flight_sandbox.dart
+++ b/lib/app/modules/sandbox/graveyard_flight_sandbox.dart
@@ -40,6 +40,12 @@ class _GraveyardFlightSandboxState extends State<GraveyardFlightSandbox>
   bool _toEnemyGrave = true; // target: top (enemy) vs bottom (own)
   bool _rotateOverride = true; // pre-checked to match "enemy grave -> flip"
 
+  // A neutral board-like palette, kept clearly distinct from the (blue)
+  // graveyard so the flying piece and the curtain reveal stay visible.
+  static const Color _pageBg = Color(0xFF2B2622); // dark warm wood
+  static const Color _lightSquare = Color(0xFFEED9B6);
+  static const Color _darkSquare = Color(0xFFB58863);
+
   static const List<chrt> _pieces = [
     chrt.pawn,
     chrt.knight,
@@ -86,7 +92,7 @@ class _GraveyardFlightSandboxState extends State<GraveyardFlightSandbox>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: brackgroundColorSolid,
+      backgroundColor: _pageBg,
       appBar: AppBar(
         backgroundColor: brackgroundColor,
         title: const Text('Sandbox — vuelo al cementerio'),
@@ -114,17 +120,27 @@ class _GraveyardFlightSandboxState extends State<GraveyardFlightSandbox>
   }
 
   Widget _board() {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        for (int j = _rows - 1; j >= 0; j--) // draw top row (high j) first
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              for (int i = 0; i < _cols; i++) _boardCell(i, j),
-            ],
-          ),
-      ],
+    return Container(
+      padding: const EdgeInsets.all(6),
+      decoration: BoxDecoration(
+        color: const Color(0xFF6B4A32), // wooden frame
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(2),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (int j = _rows - 1; j >= 0; j--) // draw top row (high j) first
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  for (int i = 0; i < _cols; i++) _boardCell(i, j),
+                ],
+              ),
+          ],
+        ),
+      ),
     );
   }
 
@@ -135,12 +151,8 @@ class _GraveyardFlightSandboxState extends State<GraveyardFlightSandbox>
         key: _cellKeys[j][i],
         width: _cell,
         height: _cell,
-        margin: const EdgeInsets.all(1),
         decoration: BoxDecoration(
-          color: (i + j).isEven
-              ? brackgroundColor
-              : brackgroundColorLight.withOpacity(0.25),
-          borderRadius: BorderRadius.circular(6),
+          color: (i + j).isEven ? _darkSquare : _lightSquare,
         ),
         child: Padding(
           padding: const EdgeInsets.all(6),

--- a/lib/app/modules/sandbox/graveyard_flight_sandbox.dart
+++ b/lib/app/modules/sandbox/graveyard_flight_sandbox.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+
+import '../../data/enums.dart';
+import '../../utils/utils.dart';
+import '../match/widgets/graveyard_flight.dart';
+
+/// Debug-only playground for the [flyToGraveyard] primitive, isolated from the
+/// match loop. A mock board (3×4) and two graveyard strips (top = "enemy",
+/// bottom = "own"); tap any cell to fly its piece to the chosen graveyard and
+/// watch the translation + optional 180° flip + curtain reveal, then land the
+/// piece in the strip. Nothing here touches game state.
+class GraveyardFlightSandbox extends StatefulWidget {
+  const GraveyardFlightSandbox({Key? key}) : super(key: key);
+
+  @override
+  State<GraveyardFlightSandbox> createState() => _GraveyardFlightSandboxState();
+}
+
+class _GraveyardFlightSandboxState extends State<GraveyardFlightSandbox>
+    with TickerProviderStateMixin {
+  static const int _rows = 4;
+  static const int _cols = 3;
+  static const double _cell = 84;
+
+  final GlobalKey _topGraveKey = GlobalKey();
+  final GlobalKey _bottomGraveKey = GlobalKey();
+  late final List<List<GlobalKey>> _cellKeys = List.generate(
+      _rows, (_) => List.generate(_cols, (_) => GlobalKey()));
+
+  // Curtain-reveal controllers, one per graveyard (mirrors GraveyardController).
+  late final AnimationController _topReveal =
+      AnimationController(vsync: this, duration: const Duration(milliseconds: 400));
+  late final AnimationController _bottomReveal =
+      AnimationController(vsync: this, duration: const Duration(milliseconds: 400));
+
+  final List<chrt> _topBuried = [];
+  final List<chrt> _bottomBuried = [];
+
+  chrt _selected = chrt.pawn;
+  bool _toEnemyGrave = true; // target: top (enemy) vs bottom (own)
+  bool _rotateOverride = true; // pre-checked to match "enemy grave -> flip"
+
+  static const List<chrt> _pieces = [
+    chrt.pawn,
+    chrt.knight,
+    chrt.bishop,
+    chrt.rock,
+    chrt.king,
+  ];
+
+  @override
+  void dispose() {
+    _topReveal.dispose();
+    _bottomReveal.dispose();
+    super.dispose();
+  }
+
+  Future<void> _revealCurtain(AnimationController c) async {
+    await c.forward();
+    await Future.delayed(const Duration(milliseconds: 400));
+    await c.reverse();
+    c.reset();
+  }
+
+  Future<void> _fly(int i, int j) async {
+    final bool toEnemy = _toEnemyGrave;
+    final fromKey = _cellKeys[j][i];
+    final toKey = toEnemy ? _topGraveKey : _bottomGraveKey;
+    final reveal = toEnemy ? _topReveal : _bottomReveal;
+    // The piece is shown in the destination graveyard's colour.
+    final gravePlayer = toEnemy ? player.black : player.white;
+
+    await flyToGraveyard(
+      context,
+      fromKey: fromKey,
+      toKey: toKey,
+      piece: getCharAsset(_selected, gravePlayer, false),
+      rotate: _rotateOverride,
+      onLaunch: () => _revealCurtain(reveal),
+    );
+
+    if (!mounted) return;
+    setState(() => (toEnemy ? _topBuried : _bottomBuried).add(_selected));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: brackgroundColorSolid,
+      appBar: AppBar(
+        backgroundColor: brackgroundColor,
+        title: const Text('Sandbox — vuelo al cementerio'),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              const SizedBox(height: 12),
+              _graveStrip(_topGraveKey, _topReveal, _topBuried, player.black,
+                  'Cementerio enemigo (arriba)'),
+              const SizedBox(height: 24),
+              _board(),
+              const SizedBox(height: 24),
+              _graveStrip(_bottomGraveKey, _bottomReveal, _bottomBuried,
+                  player.white, 'Cementerio propio (abajo)'),
+              const SizedBox(height: 24),
+              _controls(),
+              const SizedBox(height: 24),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _board() {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (int j = _rows - 1; j >= 0; j--) // draw top row (high j) first
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (int i = 0; i < _cols; i++) _boardCell(i, j),
+            ],
+          ),
+      ],
+    );
+  }
+
+  Widget _boardCell(int i, int j) {
+    return GestureDetector(
+      onTap: () => _fly(i, j),
+      child: Container(
+        key: _cellKeys[j][i],
+        width: _cell,
+        height: _cell,
+        margin: const EdgeInsets.all(1),
+        decoration: BoxDecoration(
+          color: (i + j).isEven
+              ? brackgroundColor
+              : brackgroundColorLight.withOpacity(0.25),
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(6),
+          child: getCharAsset(
+              _selected, _toEnemyGrave ? player.black : player.white, false),
+        ),
+      ),
+    );
+  }
+
+  // A graveyard strip that matches the real one's dimensions + curtain reveal.
+  Widget _graveStrip(GlobalKey key, AnimationController reveal,
+      List<chrt> buried, player p, String label) {
+    return Column(
+      children: [
+        Text(label, style: const TextStyle(color: Colors.white70, fontSize: 12)),
+        const SizedBox(height: 4),
+        SizedBox(
+          key: key,
+          width: graveyardTileWide,
+          height: graveyardHeight,
+          child: Stack(
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  border: Border.all(color: brackgroundColor),
+                  color: brackgroundColor,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: RotatedBox(
+                  quarterTurns: p == player.white ? 0 : 2,
+                  child: ListView(
+                    scrollDirection: Axis.horizontal,
+                    children: [
+                      for (final c in buried)
+                        SizedBox(
+                          width: graveyardHeight,
+                          height: graveyardHeight,
+                          child: getCharAsset(c, p, false),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+              // The curtain that hides the strip while a piece lands.
+              Center(
+                child: AnimatedBuilder(
+                  animation: reveal,
+                  builder: (context, _) => Transform.scale(
+                    scaleY: reveal.value,
+                    child: Container(
+                      width: graveyardTileWide - 4,
+                      height: graveyardHeight - 4,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(8),
+                        color: brackgroundColorSolid,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _controls() {
+    return Column(
+      children: [
+        Wrap(
+          spacing: 8,
+          children: [
+            for (final c in _pieces)
+              ChoiceChip(
+                label: Text(c.name),
+                selected: _selected == c,
+                onSelected: (_) => setState(() => _selected = c),
+              ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        SwitchListTile(
+          title: const Text('Volar al cementerio enemigo (arriba)',
+              style: TextStyle(color: Colors.white)),
+          subtitle: const Text('apagado = cementerio propio (abajo)',
+              style: TextStyle(color: Colors.white54)),
+          value: _toEnemyGrave,
+          onChanged: (v) => setState(() {
+            _toEnemyGrave = v;
+            _rotateOverride = v; // default: enemy grave flips, own doesn't
+          }),
+        ),
+        SwitchListTile(
+          title: const Text('Girar 180° en el vuelo',
+              style: TextStyle(color: Colors.white)),
+          value: _rotateOverride,
+          onChanged: (v) => setState(() => _rotateOverride = v),
+        ),
+        TextButton(
+          onPressed: () => setState(() {
+            _topBuried.clear();
+            _bottomBuried.clear();
+          }),
+          child: const Text('Vaciar cementerios'),
+        ),
+        const Text('Toca cualquier casilla para volar la pieza.',
+            style: TextStyle(color: Colors.white54, fontSize: 12)),
+      ],
+    );
+  }
+}

--- a/lib/app/routes/app_pages.dart
+++ b/lib/app/routes/app_pages.dart
@@ -13,6 +13,7 @@ import '../modules/language/bindings/language_binding.dart';
 import '../modules/language/views/language_view.dart';
 import '../modules/match/bindings/match_binding.dart';
 import '../modules/match/views/match_view.dart';
+import '../modules/sandbox/graveyard_flight_sandbox.dart';
 import '../modules/splash/bindings/splash_binding.dart';
 import '../modules/splash/views/splash_view.dart';
 import '../modules/tutorial/bindings/tutorial_binding.dart';
@@ -70,6 +71,10 @@ class AppPages {
       name: _Paths.LANGUAGE,
       page: () => LanguageView(),
       binding: LanguageBinding(),
+    ),
+    GetPage(
+      name: _Paths.GRAVEYARD_SANDBOX,
+      page: () => const GraveyardFlightSandbox(),
     ),
   ];
 }

--- a/lib/app/routes/app_routes.dart
+++ b/lib/app/routes/app_routes.dart
@@ -13,6 +13,7 @@ abstract class Routes {
   static const HALL_OF_FAME = _Paths.HALL_OF_FAME;
   static const ERRORS = _Paths.ERRORS;
   static const SPLASH = _Paths.SPLASH;
+  static const GRAVEYARD_SANDBOX = _Paths.GRAVEYARD_SANDBOX;
 }
 
 abstract class _Paths {
@@ -27,4 +28,5 @@ abstract class _Paths {
   static const HALL_OF_FAME = '/hall-of-fame';
   static const ERRORS = '/errors';
   static const SPLASH = '/splash';
+  static const GRAVEYARD_SANDBOX = '/graveyard-sandbox';
 }

--- a/lib/app/utils/gameObjects/gameState.dart
+++ b/lib/app/utils/gameObjects/gameState.dart
@@ -63,6 +63,19 @@ class GameState {
     }
   }
 
+  // The piece movements the next [applyTurnStart] will perform, gathered before
+  // any mutation so the UI can animate them (see [RuleModifier.planTurnStart]).
+  // Pure: does not touch the board or advance any modifier's cadence.
+  List<TickMove> planTurnStart() {
+    final moves = <TickMove>[];
+    for (final m in modifiers) {
+      if (m.appliesTo(possession.mine, this)) {
+        moves.addAll(m.planTurnStart(this));
+      }
+    }
+    return moves;
+  }
+
   transformPawn(Move move) {
     if (move.finalTile.char == chrt.pawn &&
         move.finalTile.j == config.promotionRow) {

--- a/lib/app/utils/gameObjects/gameState.dart
+++ b/lib/app/utils/gameObjects/gameState.dart
@@ -83,11 +83,24 @@ class GameState {
   void _sendToGrave(chrt char, possession owner) {
     final returnToOwner = modifiers.any(
         (m) => m.appliesTo(possession.mine, this) && m.returnsCapturedToOwner());
+    final buried = graveChar(char, owner);
     if (returnToOwner) {
-      enemyGraveyard.add(Tile(char, owner, null, null));
+      enemyGraveyard.add(Tile(buried, owner, null, null));
     } else {
-      myGraveyard.add(Tile(char, toggleOwner(owner), null, null));
+      myGraveyard.add(Tile(buried, toggleOwner(owner), null, null));
     }
+  }
+
+  /// The character a piece is buried as when it dies. Folds the modifiers'
+  /// display transforms so a piece turned into an oso ("todas se vuelven osos")
+  /// also *dies* as an oso — and redeploys from the graveyard as a real one —
+  /// rather than reverting to its original sprite. No-op without modifiers.
+  chrt graveChar(chrt char, possession owner) {
+    var c = char;
+    for (final m in modifiers) {
+      if (m.appliesTo(owner, this)) c = m.displayChar(c, owner);
+    }
+    return c;
   }
 
   // Side-effect captures (e.g. Oso "Embestida"), applied by [changeGameState]

--- a/lib/app/utils/gameObjects/gameState.dart
+++ b/lib/app/utils/gameObjects/gameState.dart
@@ -103,7 +103,11 @@ class GameState {
           continue;
         }
         final t = board[j][i];
-        if (t.owner == possession.enemy && t.char != chrt.empty) {
+        // Never let a side-effect capture remove a king — that would end the
+        // game with no winner detected. Kings only fall to a direct capture.
+        if (t.owner == possession.enemy &&
+            t.char != chrt.empty &&
+            t.char != chrt.king) {
           _sendToGrave(t.char, t.owner);
           t.char = chrt.empty;
           t.owner = possession.none;
@@ -140,7 +144,8 @@ class GameState {
     for (var r in board){
       List<Tile> row = [];
       for(var t in r) {
-        row.add(Tile(t.char, t.owner, t.i, t.j, idleTurns: t.idleTurns));
+        row.add(Tile(t.char, t.owner, t.i, t.j,
+            idleTurns: t.idleTurns, felledTurns: t.felledTurns));
       }
       newBoard.add(row);
     }
@@ -178,7 +183,7 @@ class GameState {
       int j = 0;
       for (var v in row.reversed) {
         revRow.add(Tile(v.char, toggleOwner(v.owner), j, i,
-            idleTurns: v.idleTurns));
+            idleTurns: v.idleTurns, felledTurns: v.felledTurns));
         j++;
       }
       reversedBoard.add(revRow);

--- a/lib/app/utils/gameObjects/tile.dart
+++ b/lib/app/utils/gameObjects/tile.dart
@@ -1,7 +1,8 @@
 import '../../data/enums.dart';
 
 class Tile {
-  Tile(this.char, this.owner, this.i, this.j, {this.idleTurns = 0});
+  Tile(this.char, this.owner, this.i, this.j,
+      {this.idleTurns = 0, this.felledTurns = 0});
 
   Tile.fromTile(Tile otherTile) :
         char = otherTile.char,
@@ -31,6 +32,11 @@ class Tile {
   /// "Marchitar" rule modifier; carried across board copies/rotations, reset to
   /// 0 when the piece moves.
   int idleTurns = 0;
+
+  /// Turns this square stays "felled" (inaccessible to the blocked side). Used
+  /// by the dynamic "Tala el tablero" modifier; 0 == normal. Carried across
+  /// board copies/rotations so a felled square stays felled as the board turns.
+  int felledTurns = 0;
 
   @override
   String toString() {

--- a/test/engine/modifier_catalog_test.dart
+++ b/test/engine/modifier_catalog_test.dart
@@ -18,7 +18,9 @@ void main() {
 
     test('every entry builds a RuleModifier and has a use + description', () {
       for (final m in modifierCatalog) {
-        expect(m.sample(), isA<RuleModifier>(), reason: m.id);
+        expect(m.build(m.defaultSide), isA<RuleModifier>(), reason: m.id);
+        expect(m.build(ModifierSide.antagonist), isA<RuleModifier>(),
+            reason: m.id);
         expect(m.uses, isNotEmpty, reason: m.id);
         expect(m.name.trim(), isNotEmpty, reason: m.id);
         expect(m.description.trim(), isNotEmpty, reason: m.id);

--- a/test/engine/rule_modifier_test.dart
+++ b/test/engine/rule_modifier_test.dart
@@ -165,6 +165,28 @@ void main() {
       expect(b[1][1].char, chrt.bishop); // untouched: no capture happened
       expect(gs.myGraveyard, isEmpty);
     });
+
+    test('never removes a king (king-safe)', () {
+      final b = _emptyBoard();
+      b[0][0] = Tile(chrt.rock, possession.mine, 0, 0); // mover
+      b[1][0] = Tile(chrt.pawn, possession.enemy, 0, 1); // captured landing
+      b[1][1] = Tile(chrt.king, possession.enemy, 1, 1); // adjacent enemy KING
+      final gs = _boardStateWith(b, const [AreaCaptureModifier()]);
+      gs.changeGameState(Move(b[0][0], b[1][0]));
+      expect(b[1][1].char, chrt.king); // survives the embestida
+    });
+  });
+
+  group('TransformAll display', () {
+    test('a transformed piece shows the oso (knight) sprite', () {
+      final b = _emptyBoard();
+      b[1][1] = Tile(chrt.bishop, possession.mine, 1, 1);
+      b[0][1] = Tile(chrt.king, possession.mine, 1, 0);
+      final gs = _boardStateWith(
+          b, const [TransformAllPiecesModifier(side: ModifierSide.protagonist)]);
+      expect(effectiveChar(b[1][1], gs), chrt.knight); // bishop shown as oso
+      expect(effectiveChar(b[0][1], gs), chrt.king); // king unchanged
+    });
   });
 
   group('applyTurnStart with no modifiers', () {
@@ -184,7 +206,7 @@ void main() {
     test('sprouts a piece on the first empty tile each turn', () {
       final b = _emptyBoard();
       b[0][0] = Tile(chrt.rock, possession.mine, 0, 0); // occupies the very first tile
-      final gs = _boardStateWith(b, const [SpawnModifier(piece: chrt.pawn)]);
+      final gs = _boardStateWith(b, [SpawnModifier(piece: chrt.pawn)]);
       gs.applyTurnStart();
       // first empty scanning j=0,i=0.. is (i=1, j=0) == board[0][1]
       expect(b[0][1].char, chrt.pawn);
@@ -196,7 +218,7 @@ void main() {
           4,
           (j) => List.generate(
               3, (i) => Tile(chrt.pawn, possession.mine, i, j)));
-      final gs = _boardStateWith(b, const [SpawnModifier()]);
+      final gs = _boardStateWith(b, [SpawnModifier()]);
       gs.applyTurnStart(); // must not throw or overwrite
       expect(b.expand((r) => r).every((t) => t.char == chrt.pawn), isTrue);
     });
@@ -207,7 +229,7 @@ void main() {
       final b = _emptyBoard();
       b[1][1] = Tile(chrt.pawn, possession.mine, 1, 1); // -> (1,2)
       b[3][0] = Tile(chrt.rock, possession.enemy, 0, 3); // top row -> off board
-      final gs = _boardStateWith(b, const [WindModifier(di: 0, dj: 1)]);
+      final gs = _boardStateWith(b, [WindModifier(di: 0, dj: 1, everyTurns: 1)]);
       gs.applyTurnStart();
       // pushed +j
       expect(b[2][1].char, chrt.pawn);
@@ -224,12 +246,33 @@ void main() {
       final b = _emptyBoard();
       b[1][1] = Tile(chrt.pawn, possession.mine, 1, 1); // -> (1,2)
       b[2][1] = Tile(chrt.bishop, possession.mine, 1, 2); // -> (1,3), moves first
-      final gs = _boardStateWith(b, const [WindModifier(di: 0, dj: 1)]);
+      final gs = _boardStateWith(b, [WindModifier(di: 0, dj: 1, everyTurns: 1)]);
       gs.applyTurnStart();
       expect(b[3][1].char, chrt.bishop);
       expect(b[2][1].char, chrt.pawn);
       expect(b[1][1].char, chrt.empty);
       expect(gs.myGraveyard, isEmpty); // nobody blown off
+    });
+
+    test('only gusts every `everyTurns` turns', () {
+      final b = _emptyBoard();
+      b[1][1] = Tile(chrt.pawn, possession.mine, 1, 1);
+      final gs = _boardStateWith(b, [WindModifier(di: 0, dj: 1, everyTurns: 3)]);
+      gs.applyTurnStart(); // 1
+      gs.applyTurnStart(); // 2 — no gust yet
+      expect(b[1][1].char, chrt.pawn);
+      gs.applyTurnStart(); // 3 — gust
+      expect(b[2][1].char, chrt.pawn);
+      expect(b[1][1].char, chrt.empty);
+    });
+
+    test('a king is anchored — never moved or blown off', () {
+      final b = _emptyBoard();
+      b[3][0] = Tile(chrt.king, possession.enemy, 0, 3); // top row: would blow off
+      final gs = _boardStateWith(b, [WindModifier(di: 0, dj: 1, everyTurns: 1)]);
+      gs.applyTurnStart();
+      expect(b[3][0].char, chrt.king); // still there
+      expect(gs.enemyGraveyard, isEmpty);
     });
   });
 
@@ -267,30 +310,34 @@ void main() {
     });
   });
 
-  group('FelledTilesModifier (Tala el tablero)', () {
-    test('the protagonist cannot enter a felled tile; the antagonist can', () {
-      // (1,2) is felled. A rock at (1,1) wants to step onto it.
-      final felled = [
-        [1, 2]
-      ];
-      final gs = _boardStateWith(
-          _emptyBoard(), [FelledTilesModifier(felled)]); // side: protagonist
-      // protagonist == mine in a default state -> blocked.
+  group('FelledTilesModifier (Tala dinámica)', () {
+    test('seeds a felled square the protagonist cannot enter (antagonist can)',
+        () {
+      final gs = _boardStateWith(_emptyBoard(), const [FelledTilesModifier()]);
+      gs.applyTurnStart(); // seeds the centre: board[2][1] == (i=1, j=2)
+      expect(gs.board[2][1].felledTurns, greaterThan(0));
+      // protagonist (mine, default state) blocked; antagonist allowed.
       expect(checkIfValidMove(
           _move(chrt.rock, possession.mine, 1, 1, 1, 2), gs, true), isFalse);
-      // the antagonist (enemy) may still enter it.
       expect(checkIfValidMove(
           _move(chrt.rock, possession.enemy, 1, 1, 1, 2), gs, true), isTrue);
     });
 
-    test('a non-felled tile stays reachable', () {
-      final gs = _boardStateWith(_emptyBoard(), [
-        FelledTilesModifier(const [
-          [0, 0]
-        ])
-      ]);
-      expect(checkIfValidMove(
-          _move(chrt.rock, possession.mine, 1, 1, 1, 2), gs, true), isTrue);
+    test('a felled square counts down and expires', () {
+      final b = _emptyBoard();
+      b[0][0].felledTurns = 1; // a felled corner, far from the centre seed
+      final gs = _boardStateWith(b, const [FelledTilesModifier(duration: 2)]);
+      gs.applyTurnStart(); // decrements the corner 1 -> 0 (then seeds the centre)
+      expect(b[0][0].felledTurns, 0);
+    });
+
+    test('spreads to a neighbour on later turns', () {
+      final gs = _boardStateWith(_emptyBoard(), const [FelledTilesModifier()]);
+      gs.applyTurnStart(); // seed centre
+      gs.applyTurnStart(); // spread to a neighbour
+      final felled =
+          gs.board.expand((r) => r).where((t) => t.felledTurns > 0).length;
+      expect(felled, greaterThanOrEqualTo(2));
     });
   });
 }

--- a/test/engine/rule_modifier_test.dart
+++ b/test/engine/rule_modifier_test.dart
@@ -317,6 +317,33 @@ void main() {
       expect(b[3][0].char, chrt.king); // still there
       expect(gs.enemyGraveyard, isEmpty);
     });
+
+    test('a king NOT on the back edge is blown one row back like any piece', () {
+      final b = _emptyBoard();
+      b[1][0] = Tile(chrt.king, possession.enemy, 0, 1); // room ahead at (0,2)
+      final gs = _boardStateWith(b, [WindModifier(everyTurns: 1)]);
+      gs.applyTurnStart();
+      expect(b[2][0].char, chrt.king); // shifted back
+      expect(b[1][0].char, chrt.empty);
+      expect(gs.enemyGraveyard, isEmpty); // never falls off
+    });
+
+    test('the gust is reported by planTurnStart before it mutates', () {
+      final b = _emptyBoard();
+      b[1][1] = Tile(chrt.pawn, possession.enemy, 1, 1); // -> (1,2)
+      b[3][2] = Tile(chrt.rock, possession.enemy, 2, 3); // -> off the back edge
+      final gs = _boardStateWith(b, [WindModifier(everyTurns: 1)]);
+      final planned = gs.planTurnStart();
+      // Two shoves reported, board still untouched (pure).
+      expect(planned.length, 2);
+      expect(b[1][1].char, chrt.pawn);
+      expect(b[3][2].char, chrt.rock);
+      // the off-edge shove is a normal board slide carrying the piece past the
+      // last row (toJ == height), not a toGrave flight.
+      final offEdge = planned.firstWhere((m) => m.fromJ == 3);
+      expect(offEdge.toJ, gs.board.length);
+      expect(offEdge.toGrave, isFalse);
+    });
   });
 
   group('WitherModifier (Marchitar)', () {
@@ -341,6 +368,21 @@ void main() {
       gs.applyTurnStart(); // idle 1 again (on the new tile)
       expect(b[2][1].char, chrt.rock); // still alive
       expect(gs.myGraveyard, isEmpty);
+    });
+
+    test('planTurnStart reports the piece about to wither (as a toGrave move)',
+        () {
+      final b = _emptyBoard();
+      b[1][1] = Tile(chrt.bishop, possession.mine, 1, 1)..idleTurns = 1;
+      final gs = _boardStateWith(b, const [WitherModifier(turns: 2)]);
+      // idle is 1, turns is 2 -> next tick it dies; the plan announces it now,
+      // without touching the board.
+      final planned = gs.planTurnStart();
+      expect(planned.length, 1);
+      expect(planned.first.toGrave, isTrue);
+      expect(planned.first.fromI, 1);
+      expect(planned.first.fromJ, 1);
+      expect(b[1][1].char, chrt.bishop); // pure: not yet dead
     });
 
     test('the king never withers', () {

--- a/test/engine/rule_modifier_test.dart
+++ b/test/engine/rule_modifier_test.dart
@@ -70,6 +70,22 @@ void main() {
           _move(chrt.rock, possession.enemy, 1, 3, 1, 1), gs, true), isFalse);
     });
 
+    test('a piece in between blocks the two-step leap', () {
+      final b = _emptyBoard();
+      b[0][1] = Tile(chrt.rock, possession.mine, 1, 0); // mover at (1,0)
+      b[1][1] = Tile(chrt.pawn, possession.mine, 1, 1); // blocker at midpoint
+      final gs = _boardStateWith(b, const [DoubleStepModifier()]);
+      // the leap to (1,2) is vetoed because the midpoint (1,1) is occupied.
+      expect(checkIfValidMove(Move(b[0][1], b[2][1]), gs, true), isFalse);
+    });
+
+    test('the two-step leap is allowed when the path is clear', () {
+      final b = _emptyBoard();
+      b[0][1] = Tile(chrt.rock, possession.mine, 1, 0);
+      final gs = _boardStateWith(b, const [DoubleStepModifier()]);
+      expect(checkIfValidMove(Move(b[0][1], b[2][1]), gs, true), isTrue);
+    });
+
     test('stable targeting follows the protagonist across a rotation', () {
       final gs =
           _stateWith(const [DoubleStepModifier(side: ModifierSide.protagonist)]);
@@ -187,6 +203,18 @@ void main() {
       expect(effectiveChar(b[1][1], gs), chrt.knight); // bishop shown as oso
       expect(effectiveChar(b[0][1], gs), chrt.king); // king unchanged
     });
+
+    test('a transformed piece is buried *as* an oso (dies a knight)', () {
+      final b = _emptyBoard();
+      b[0][0] = Tile(chrt.rock, possession.mine, 0, 0); // captor
+      b[1][0] = Tile(chrt.bishop, possession.enemy, 0, 1); // enemy, shown as oso
+      final gs = _boardStateWith(
+          b, const [TransformAllPiecesModifier(side: ModifierSide.antagonist)]);
+      gs.changeGameState(Move(b[0][0], b[1][0]));
+      expect(gs.myGraveyard.length, 1);
+      // stored as a knight (oso), not the bishop it used to be.
+      expect(gs.myGraveyard.first.char, chrt.knight);
+    });
   });
 
   group('applyTurnStart with no modifiers', () {
@@ -225,39 +253,54 @@ void main() {
   });
 
   group('WindModifier (Viento)', () {
-    test('pushes pieces one step; those blown off go to the graveyard', () {
+    test('blows the opponent one row back; only the opponent, off-edge to grave',
+        () {
       final b = _emptyBoard();
-      b[1][1] = Tile(chrt.pawn, possession.mine, 1, 1); // -> (1,2)
-      b[3][0] = Tile(chrt.rock, possession.enemy, 0, 3); // top row -> off board
-      final gs = _boardStateWith(b, [WindModifier(di: 0, dj: 1, everyTurns: 1)]);
+      b[1][0] = Tile(chrt.pawn, possession.enemy, 0, 1); // -> (0,2)
+      b[3][2] = Tile(chrt.rock, possession.enemy, 2, 3); // frontier -> off board
+      b[1][2] = Tile(chrt.bishop, possession.mine, 2, 1); // caster's own: untouched
+      final gs = _boardStateWith(b, [WindModifier(everyTurns: 1)]);
       gs.applyTurnStart();
-      // pushed +j
-      expect(b[2][1].char, chrt.pawn);
-      expect(b[2][1].owner, possession.mine);
-      expect(b[1][1].char, chrt.empty); // origin cleared
-      // rock blown off the far edge -> enemy graveyard, origin cleared
-      expect(b[3][0].char, chrt.empty);
+      expect(b[2][0].char, chrt.pawn);
+      expect(b[2][0].owner, possession.enemy);
+      expect(b[1][0].char, chrt.empty); // origin cleared
+      // rock blown off the back edge -> enemy graveyard
+      expect(b[3][2].char, chrt.empty);
       expect(gs.enemyGraveyard.length, 1);
       expect(gs.enemyGraveyard.first.char, chrt.rock);
       expect(gs.enemyGraveyard.first.owner, possession.enemy);
+      // the caster's own piece never moves
+      expect(b[1][2].char, chrt.bishop);
+      expect(gs.myGraveyard, isEmpty);
     });
 
-    test('adjacent pieces shift without colliding', () {
+    test('a packed column cascades one step (frontier first)', () {
       final b = _emptyBoard();
-      b[1][1] = Tile(chrt.pawn, possession.mine, 1, 1); // -> (1,2)
-      b[2][1] = Tile(chrt.bishop, possession.mine, 1, 2); // -> (1,3), moves first
-      final gs = _boardStateWith(b, [WindModifier(di: 0, dj: 1, everyTurns: 1)]);
+      b[1][1] = Tile(chrt.pawn, possession.enemy, 1, 1); // -> (1,2)
+      b[2][1] = Tile(chrt.bishop, possession.enemy, 1, 2); // -> (1,3), moves first
+      final gs = _boardStateWith(b, [WindModifier(everyTurns: 1)]);
       gs.applyTurnStart();
       expect(b[3][1].char, chrt.bishop);
       expect(b[2][1].char, chrt.pawn);
       expect(b[1][1].char, chrt.empty);
-      expect(gs.myGraveyard, isEmpty); // nobody blown off
+      expect(gs.enemyGraveyard, isEmpty); // nobody blown off
+    });
+
+    test('a piece jammed behind an anchored king holds its square', () {
+      final b = _emptyBoard();
+      b[2][1] = Tile(chrt.pawn, possession.enemy, 1, 2); // wants (1,3)
+      b[3][1] = Tile(chrt.king, possession.enemy, 1, 3); // king dams it
+      final gs = _boardStateWith(b, [WindModifier(everyTurns: 1)]);
+      gs.applyTurnStart();
+      expect(b[3][1].char, chrt.king); // king didn't move
+      expect(b[2][1].char, chrt.pawn); // blocked -> stays
+      expect(gs.enemyGraveyard, isEmpty);
     });
 
     test('only gusts every `everyTurns` turns', () {
       final b = _emptyBoard();
-      b[1][1] = Tile(chrt.pawn, possession.mine, 1, 1);
-      final gs = _boardStateWith(b, [WindModifier(di: 0, dj: 1, everyTurns: 3)]);
+      b[1][1] = Tile(chrt.pawn, possession.enemy, 1, 1);
+      final gs = _boardStateWith(b, [WindModifier(everyTurns: 3)]);
       gs.applyTurnStart(); // 1
       gs.applyTurnStart(); // 2 — no gust yet
       expect(b[1][1].char, chrt.pawn);
@@ -266,10 +309,10 @@ void main() {
       expect(b[1][1].char, chrt.empty);
     });
 
-    test('a king is anchored — never moved or blown off', () {
+    test('an enemy king on the frontier is anchored — never blown off', () {
       final b = _emptyBoard();
-      b[3][0] = Tile(chrt.king, possession.enemy, 0, 3); // top row: would blow off
-      final gs = _boardStateWith(b, [WindModifier(di: 0, dj: 1, everyTurns: 1)]);
+      b[3][0] = Tile(chrt.king, possession.enemy, 0, 3); // frontier: would blow off
+      final gs = _boardStateWith(b, [WindModifier(everyTurns: 1)]);
       gs.applyTurnStart();
       expect(b[3][0].char, chrt.king); // still there
       expect(gs.enemyGraveyard, isEmpty);


### PR DESCRIPTION
First step of **campaign integration**: make the rule modifiers actually playable, so every power/joker can be verified by hand. No map / campaign UI yet — just a debug launcher.

## What
- **`SandboxConfig`** — a match route argument that launches a **solo** match (classic 3×4 board) with a list of `RuleModifier`s active.
- **`MatchController`** — parses the argument (`SandboxConfig` → solo mode + modifiers), seeds `GameState.modifiers`, and wires **`_runTurnTick()`** (`applyTurnStart()` + repaint) right after each `rotate()`/`togglePlayersTurn()`. **No-op without modifiers**, so vanilla matches are byte-for-byte unchanged.
- **`HomeController.startSandbox(modifier)`** navigates into it.
- **Home view** — a **`kDebugMode`-only** FAB (🧪) opens a picker over `modifierCatalog` to launch any power/joker. **Never shown in release builds.**

## How to try it
Run a debug build → tap the 🧪 button on the home screen → pick a modifier → play. E.g. **Rebrote** (Llama) spawns a boss piece each of the AI's turns; **Doble paso** lets your pieces jump 2; **Todas se vuelven osos** transforms the AI's army.

## Notes / deferred
- **Boss powers** target the antagonist (the AI, black); **jokers** target the protagonist (you, white). The stable side-identity from #20 makes this hold across rotations.
- Classic 3×4 board only — the 5×4 board needs UI layout work (`board.png` is sized for 3 cols); deferred.
- **Boss N-lives + checkmate-as-win** not wired yet (next PR).
- Tick effects repaint via `gs.update` (no slide animation yet) — fine for verification.

## Verification
- `flutter analyze` — **0 errors**.
- `flutter test test/engine/` — **63/63**.
- `flutter build web` — compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)